### PR TITLE
Add GitHub Actions workflows for building release zip

### DIFF
--- a/.github/workflows/manually-build-zip.yml
+++ b/.github/workflows/manually-build-zip.yml
@@ -1,0 +1,19 @@
+name: Build release zip
+
+on:
+  workflow_dispatch
+
+jobs:
+  build:
+    name: Build release zip
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Build plugin # Remove or modify this step as needed
+      run: |
+        composer install --no-dev
+
+    - name: Generate zip
+      uses: 10up/action-wordpress-plugin-build-zip@stable

--- a/.github/workflows/on-push-build-zip.yml
+++ b/.github/workflows/on-push-build-zip.yml
@@ -1,0 +1,21 @@
+name: Build release zip
+
+on:
+  push:
+    branches:
+    - main
+
+jobs:
+  build:
+    name: Build release zip
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Build plugin # Remove or modify this step as needed
+      run: |
+        composer install --no-dev
+
+    - name: Generate zip
+      uses: 10up/action-wordpress-plugin-build-zip@stable


### PR DESCRIPTION
This pull request adds two GitHub Actions workflows, "manually-build-zip.yml" and "on-push-build-zip.yml", for building the release zip of the WordPress plugin. These workflows use the "10up/action-wordpress-plugin-build-zip" action to generate the zip file.