### PR TITLE
Add wp-loupe.pot

### DIFF
--- a/.github/workflows/on-push-build-zip.yml
+++ b/.github/workflows/on-push-build-zip.yml
@@ -1,6 +1,11 @@
 name: On Release, Build release zip
 
-on: release
+on:
+  push:
+    tags:
+      - "*"
+    branches:
+      - main
 
 jobs:
   build:

--- a/includes/class-wploupe-settings-page.php
+++ b/includes/class-wploupe-settings-page.php
@@ -49,7 +49,7 @@ class WPLoupe_Settings_Page {
 	public function wp_loupe_setup_fields() {
 		register_setting( 'wp-loupe', 'wp_loupe_custom_post_types' );
 
-		add_settings_field( 'wp_loupe_post_type_field', __( 'Select Custom 	Post Type', 'wp-loupe' ), [ $this, 'wp_loupe_post_type_field_callback' ], 'wp-loupe', 'wp_loupe_section' );
+		add_settings_field( 'wp_loupe_post_type_field', __( 'Select Custom Post Type', 'wp-loupe' ), [ $this, 'wp_loupe_post_type_field_callback' ], 'wp-loupe', 'wp_loupe_section' );
 		add_settings_field( 'wp_loupe_reindex_field', __( 'Reindex Search Index', 'wp-loupe' ), [ $this, 'wp_loupe_reindex_field_callback' ], 'wp-loupe', 'wp_loupe_section' );
 	}
 

--- a/languages/wp-loupe.pot
+++ b/languages/wp-loupe.pot
@@ -1,0 +1,42 @@
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: WP Loupe\n"
+"POT-Creation-Date: 2024-01-22 12:28+0100\n"
+"PO-Revision-Date: 2024-01-22 12:25+0100\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+"X-Generator: Poedit 3.4.2\n"
+"X-Poedit-Basepath: ..\n"
+"X-Poedit-Flags-xgettext: --add-comments=translators:\n"
+"X-Poedit-WPHeader: wp-loupe.php\n"
+"X-Poedit-SourceCharset: UTF-8\n"
+"X-Poedit-KeywordsList: __;_e;_n:1,2;_x:1,2c;_ex:1,2c;_nx:4c,1,2;esc_attr__;"
+"esc_attr_e;esc_attr_x:1,2c;esc_html__;esc_html_e;esc_html_x:1,2c;_n_noop:1,2;"
+"_nx_noop:3c,1,2;__ngettext_noop:1,2\n"
+"X-Poedit-SearchPath-0: .\n"
+"X-Poedit-SearchPathExcluded-0: *.min.js\n"
+"X-Poedit-SearchPathExcluded-1: vendor\n"
+
+#: includes/class-wploupe-settings-page.php:52
+msgid "Select Custom Post Type"
+msgstr ""
+
+#: includes/class-wploupe-settings-page.php:53
+msgid "Reindex Search Index"
+msgstr ""
+
+#: wp-loupe.php:247
+msgid "Reindexing in progress"
+msgstr ""
+
+#. Description of the plugin/theme
+msgid ""
+"Search engine for WordPress. It uses the Loupe search engine to create a "
+"search index for your posts and pages and to search the index."
+msgstr ""
+

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: search, loupe, posts, pages, custom post types
 Requires at least: 6.2
 Requires PHP: 7.4
 Tested up to: 6.4
-Stable tag: 0.0.6
+Stable tag: 0.0.7
 Donate link: https://paypal.me/PerSoderlind
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/wp-loupe.php
+++ b/wp-loupe.php
@@ -12,7 +12,7 @@
  * Plugin URI: https://github.com/soderlind/wp-loupe
  * GitHub Plugin URI: https://github.com/soderlind/wp-loupe
  * Description: Search engine for WordPress. It uses the Loupe search engine to create a search index for your posts and pages and to search the index.
- * Version:     0.0.6
+ * Version:     0.0.7
  * Author:      Per Soderlind
  * Author URI:  https://soderlind.no
  * Text Domain: wp-loupe
@@ -87,6 +87,8 @@ class WPLoupe {
 		\add_action( 'admin_init', [ $this, 'handle_reindex' ] );
 
 		\add_action( 'wp_footer', [ $this, 'action_wp_footer' ] );
+
+		\load_plugin_textdomain( 'wp-loupe', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
 	}
 
 	/**


### PR DESCRIPTION
This pull request adds the `wp-loupe.pot` file to the repository, which contains the translation strings for the WP Loupe plugin.