### PR TITLE
Bump version to 0.0.18 and update stable tag in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.18] - 2025-02-03
+
+### Changed
+
+- Fixed return value in posts_pre_query to return null instead of posts for better WP Core integration
+
 ## [0.0.17] - 2025-02-02
 
 ### Added
@@ -93,3 +99,4 @@ All notable changes to this project will be documented in this file.
 [0.0.15]: https://github.com/soderlind/wp-loupe/releases/tag/0.0.15
 [0.0.16]: https://github.com/soderlind/wp-loupe/releases/tag/0.0.16
 [0.0.17]: https://github.com/soderlind/wp-loupe/releases/tag/0.0.17
+[0.0.18]: https://github.com/soderlind/wp-loupe/releases/tag/0.0.18

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"type": "wordpress-plugin",
 	"description": "Search engine for WordPress. It uses the Loupe search engine to create a search index for your posts and pages and to search the index.",
 	"homepage": "https://github.com/soderlind/wp-loupe",
-	"version": "0.0.17",
+	"version": "0.0.18",
 	"license": "GPL-2.0+",
 	"authors": [
 		{

--- a/includes/class-wp-loupe-search.php
+++ b/includes/class-wp-loupe-search.php
@@ -44,7 +44,7 @@ class WP_Loupe_Search {
 	 */
 	public function posts_pre_query( $posts, \WP_Query $query ) {
 		if ( ! $this->should_intercept_query( $query ) ) {
-			return $posts;
+			return null;
 		}
 
 		$query->set( 'post_type', $this->post_types );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-loupe",
-	"version": "0.0.17",
+	"version": "0.0.18",
 	"description": "Enhance the search functionality of your WordPress site with WP Loupe.",
 	"main": "index.js",
 	"scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -45,6 +45,10 @@ WP Loupe uses the [Loupe search engine](https://github.com/loupe-php/loupe/blob/
 
 == Changelog ==
 
+= 0.0.18 =
+* Fixed return value in posts_pre_query to return null instead of posts for better WP Core integration
+
+
 = 0.0.17 =
 * Added wp_loupe_posts_per_page filter hook for customizing posts per page
 * Added PHPDoc blocks for all class properties in search class

--- a/wp-loupe.php
+++ b/wp-loupe.php
@@ -12,7 +12,7 @@
  * Plugin URI: https://github.com/soderlind/wp-loupe
  * GitHub Plugin URI: https://github.com/soderlind/wp-loupe
  * Description: Search engine for WordPress. It uses the Loupe search engine to create a search index for your posts and pages and to search the index.
- * Version:     0.0.17
+ * Version:     0.0.18
  * Author:      Per Soderlind
  * Author URI:  https://soderlind.no
  * Text Domain: wp-loupe


### PR DESCRIPTION
This pull request includes several changes to update the version of the WP Loupe plugin to 0.0.18 and improve its integration with WordPress Core. The most important changes are summarized below:

### Version Update:

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L6-R6): Updated the plugin version from 0.0.17 to 0.0.18.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the plugin version from 0.0.17 to 0.0.18.
* [`wp-loupe.php`](diffhunk://#diff-0748dd44810f34aab89de4f1c30508f3daf827a816ae5e86010cb5bb0e845cccL15-R15): Updated the plugin version from 0.0.17 to 0.0.18.

### Bug Fixes:

* [`includes/class-wp-loupe-search.php`](diffhunk://#diff-8611c0333690318dcdfb5aaf2f2d1aaf49c104f166d9abf872255cb053ddfee8L47-R47): Fixed the return value in `posts_pre_query` to return null instead of posts for better WordPress Core integration.

### Documentation:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R10): Added a new entry for version 0.0.18, documenting the fix in `posts_pre_query`.
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR102): Added a link to the release tag for version 0.0.18.
* [`readme.txt`](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R48-R51): Updated the changelog to include the fix in `posts_pre_query` for version 0.0.18.