### PR TITLE
Delete cache when; reindexing or, saving, updating or deleting a post.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.1] - 2025-03-01
+
+### Fixed
+
+- Clear search results cache when reindexing, saving, updating or deleting posts.
+
 ## [0.1.0] - 2025-02-28
 
 ### Schema Management:
@@ -149,3 +155,4 @@ All notable changes to this project will be documented in this file.
 [0.0.20]: https://github.com/soderlind/wp-loupe/releases/tag/0.0.20
 [0.0.30]: https://github.com/soderlind/wp-loupe/releases/tag/0.0.30
 [0.1.0]: https://github.com/soderlind/wp-loupe/releases/tag/0.1.0
+[0.1.1]: https://github.com/soderlind/wp-loupe/releases/tag/0.1.1

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"type": "wordpress-plugin",
 	"description": "Search engine for WordPress. It uses the Loupe search engine to create a search index for your posts and pages and to search the index.",
 	"homepage": "https://github.com/soderlind/wp-loupe",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"license": "GPL-2.0+",
 	"authors": [
 		{

--- a/includes/class-wp-loupe-indexer.php
+++ b/includes/class-wp-loupe-indexer.php
@@ -57,6 +57,8 @@ class WP_Loupe_Indexer {
 			return;
 		}
 
+		WP_Loupe_Utils::remove_transient( 'wp_loupe_search_' );
+
 		$document = $this->prepare_document( $post );
 		$loupe    = $this->loupe[ $post->post_type ];
 		$loupe->deleteDocument( $post_id );
@@ -73,6 +75,7 @@ class WP_Loupe_Indexer {
 		if ( ! 'publish' === $previous_status ) {
 			return;
 		}
+		WP_Loupe_Utils::remove_transient( 'wp_loupe_search_' );
 		// Verify if is trashing multiple posts.
 		if ( isset( $_GET[ 'post' ] ) && is_array( $_GET[ 'post' ] ) ) {
 			\check_admin_referer( 'bulk-posts' );
@@ -132,9 +135,10 @@ class WP_Loupe_Indexer {
 	 * @return void
 	 */
 	public function reindex_all() {
-		WP_Loupe_Utils::dump( [ 'reindex_all > post_types', $this->post_types ] );
+		WP_Loupe_Utils::dump( [ 'post_types', $this->post_types ] );
 
 		$this->delete_index();
+		WP_Loupe_Utils::remove_transient( 'wp_loupe_search_' );
 		$this->init();
 
 		foreach ( $this->post_types as $post_type ) {

--- a/includes/class-wp-loupe-loader.php
+++ b/includes/class-wp-loupe-loader.php
@@ -51,7 +51,7 @@ class WP_Loupe_Loader {
 	private function setup_post_types() {
 		add_filter( 'wp_loupe_post_types', array( $this, 'filter_post_types' ) );
 		$this->post_types = apply_filters( 'wp_loupe_post_types', array( 'post', 'page' ) );
-		WP_Loupe_Utils::dump( [ 'setup_post_types > post_types', $this->post_types ] );
+		WP_Loupe_Utils::dump( [ 'post_types', $this->post_types ] );
 	}
 
 	/**

--- a/includes/class-wp-loupe-schema-manager.php
+++ b/includes/class-wp-loupe-schema-manager.php
@@ -69,12 +69,12 @@ class WP_Loupe_Schema_Manager {
 
 		$processed_fields = [];
 		foreach ( $schema as $field => $settings ) {
-			WP_Loupe_Utils::dump( [ 'get_fields_by_type > settings >' . $field, $settings ] );
+			WP_Loupe_Utils::dump( [ 'settings >' . $field, $settings ] );
 			$processed_fields[] = $this->process_field( $field, $settings, $type );
 		}
 
-		$processed_fields               = array_unique( $processed_fields, SORT_REGULAR );
-		$processed_fields               = array_values( array_filter( $processed_fields ) );
+		$processed_fields                 = array_unique( $processed_fields, SORT_REGULAR );
+		$processed_fields                 = array_values( array_filter( $processed_fields ) );
 		$this->fields_cache[ $cache_key ] = $processed_fields;
 
 		return $processed_fields;

--- a/includes/class-wp-loupe-search.php
+++ b/includes/class-wp-loupe-search.php
@@ -57,7 +57,7 @@ class WP_Loupe_Search {
 		$query->set( 'post_type', $this->post_types );
 		$search_term = $this->prepare_search_term( $query->query_vars[ 'search_terms' ] );
 		$hits        = $this->search( $search_term );
-		WP_Loupe_Utils::dump( [ 'posts_pre_query > hits', $hits ] );
+		WP_Loupe_Utils::dump( [ 'hits', $hits ] );
 
 		// Get all search results first
 		$all_posts               = $this->create_post_objects( $hits );

--- a/includes/trait-wp-loupe-shared.php
+++ b/includes/trait-wp-loupe-shared.php
@@ -26,16 +26,13 @@ trait WP_Loupe_Shared {
 		$schema         = $schema_manager->get_schema_for_post_type( $post_type );
 
 		$indexable = $schema_manager->get_indexable_fields( $schema );
-		WP_Loupe_Utils::dump( [ 'create_loupe_instance > indexable A', $indexable ] );
 		// sort indexable fields, based on weight. The higher the weight, the higher the field is in the list
 		uasort( $indexable, function ($a, $b) {
 			return $b[ 'weight' ] <=> $a[ 'weight' ];
 		} );
-		WP_Loupe_Utils::dump( [ 'create_loupe_instance > indexable B', $indexable ] );
-		$indexable = array_map( function ($field) {
+		$indexable  = array_map( function ($field) {
 			return "{$field[ 'field' ]}";
 		}, $indexable );
-		WP_Loupe_Utils::dump( [ 'create_loupe_instance > indexable C', $indexable ] );
 		$filterable = $schema_manager->get_filterable_fields( $schema );
 
 		$sortable = $schema_manager->get_sortable_fields( $schema );
@@ -43,9 +40,9 @@ trait WP_Loupe_Shared {
 			return "{$field[ 'field' ]}";
 		}, $sortable );
 
-		WP_Loupe_Utils::dump( [ 'create_loupe_instance > filterable', $filterable ] );
-		WP_Loupe_Utils::dump( [ 'create_loupe_instance > sortable', $sortable ] );
-		WP_Loupe_Utils::dump( [ 'create_loupe_instance > indexable', $indexable ] );
+		WP_Loupe_Utils::dump( [ 'filterable', $filterable ] );
+		WP_Loupe_Utils::dump( [ 'sortable', $sortable ] );
+		WP_Loupe_Utils::dump( [ 'indexable', $indexable ] );
 		$configuration = Configuration::create()
 			->withPrimaryKey( 'id' )
 			->withSearchableAttributes( $indexable )

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-loupe",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"description": "Enhance the search functionality of your WordPress site with WP Loupe.",
 	"main": "index.js",
 	"scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: search, loupe, posts, pages, custom post types, typo-tolerant, fast search
 Requires at least: 6.3
 Requires PHP: 8.1
 Tested up to: 6.7
-Stable tag: 0.1.0
+Stable tag: 0.1.1
 Donate link: https://paypal.me/PerSoderlind
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -104,6 +104,19 @@ For usage examples, see the plugin's README.md file.
 
 == Changelog ==
 
+= 0.1.1 =
+* Clear search results cache when reindexing, saving, updating or deleting posts
+
+= 0.1.0 =
+* Added new WP_Loupe_Schema_Manager class for schema configurations
+* Added methods for indexable, filterable, and sortable fields
+* Added prepare_document method in WP_Loupe_Indexer
+* Enhanced reindex_all method with prepare_document
+* Improved search method in WP_Loupe_Search with schema-based fields
+* Added search results caching for better performance
+* Updated create_post_objects method for efficient post fetching
+* Added schema customization documentation in README.md
+
 = 0.0.31 =
 * Update readme.txt
 

--- a/wp-loupe.php
+++ b/wp-loupe.php
@@ -12,7 +12,7 @@
  * Plugin URI: https://github.com/soderlind/wp-loupe
  * GitHub Plugin URI: https://github.com/soderlind/wp-loupe
  * Description: Search engine for WordPress. It uses the Loupe search engine to create a search index for your posts and pages and to search the index.
- * Version:     0.1.0
+ * Version:     0.1.1
  * Author:      Per Soderlind
  * Author URI:  https://soderlind.no
  * Text Domain: wp-loupe


### PR DESCRIPTION
This pull request includes several changes to the WP Loupe plugin, focusing on version updates, transient removal, and code cleanup. The most important changes include updating the plugin version, adding a new method for removing transients, and cleaning up debug statements.

Version updates:

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L6-R6): Updated the version from `0.1.0` to `0.1.1`.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `0.1.0` to `0.1.1`.
* [`readme.txt`](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L7-R7): Updated the stable tag version from `0.1.0` to `0.1.1`.
* [`wp-loupe.php`](diffhunk://#diff-0748dd44810f34aab89de4f1c30508f3daf827a816ae5e86010cb5bb0e845cccL15-R15): Updated the plugin version from `0.1.0` to `0.1.1`.

Transient removal:

* [`includes/class-wp-loupe-indexer.php`](diffhunk://#diff-05a01153dae4d937761043e52e0f0b5c2b05742142885bab821375bb539f148cR60-R61): Added calls to `WP_Loupe_Utils::remove_transient` in multiple methods to remove transients related to the search index. [[1]](diffhunk://#diff-05a01153dae4d937761043e52e0f0b5c2b05742142885bab821375bb539f148cR60-R61) [[2]](diffhunk://#diff-05a01153dae4d937761043e52e0f0b5c2b05742142885bab821375bb539f148cR78) [[3]](diffhunk://#diff-05a01153dae4d937761043e52e0f0b5c2b05742142885bab821375bb539f148cL135-R141)
* [`includes/class-wp-loupe-utils.php`](diffhunk://#diff-387a78d6ac7bd584490afcce9f620c93444effee73f3e120aa74f67a5562956aL90-R189): Added a new method `remove_transient` to remove transients from the database, along with a helper method `get_transients`.

Code cleanup:

* Removed or modified debug statements using `WP_Loupe_Utils::dump` across several files to streamline the debugging output. [[1]](diffhunk://#diff-05a01153dae4d937761043e52e0f0b5c2b05742142885bab821375bb539f148cL135-R141) [[2]](diffhunk://#diff-d84e436ea0b5f8bacd581539b17867fbcf4998a3d98b9a3f4ab013af45e21fe4L54-R54) [[3]](diffhunk://#diff-5ce102602bdf4b1091c82da8885fa0698e8c602c6ee436bbbd43460a964c6c97L72-R72) [[4]](diffhunk://#diff-8611c0333690318dcdfb5aaf2f2d1aaf49c104f166d9abf872255cb053ddfee8L60-R60) [[5]](diffhunk://#diff-eb2e83378c7dc27cd3dce614fb1135a28a8b0be20b9a44e7c4e1a4b652b55adfL29-R45)