### PR TITLE
Bump version to 0.1.6 and perform housekeeping updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.6] - 2025-03-06
+
+### Changed
+
+- Housekeeping
+
+
 ## [0.1.5] - 2025-03-06
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"type": "wordpress-plugin",
 	"description": "Search engine for WordPress. It uses the Loupe search engine to create a search index for your posts and pages and to search the index.",
 	"homepage": "https://github.com/soderlind/wp-loupe",
-	"version": "0.1.5",
+	"version": "0.1.6",
 	"license": "GPL-2.0+",
 	"authors": [
 		{

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0ead7ed36b69db3a4d19235f61e4ea92",
+    "content-hash": "33f63e70f1e0f25ca5d933cff5091f24",
     "packages": [
         {
             "name": "doctrine/dbal",

--- a/includes/class-wp-loupe-indexer.php
+++ b/includes/class-wp-loupe-indexer.php
@@ -135,7 +135,7 @@ class WP_Loupe_Indexer {
 	 * @return void
 	 */
 	public function reindex_all() {
-		WP_Loupe_Utils::dump( [ 'post_types', $this->post_types ] );
+		
 
 		$this->delete_index();
 		WP_Loupe_Utils::remove_transient( 'wp_loupe_search_' );

--- a/includes/class-wp-loupe-loader.php
+++ b/includes/class-wp-loupe-loader.php
@@ -42,8 +42,6 @@ class WP_Loupe_Loader {
 		require_once WP_LOUPE_PATH . 'includes/class-wp-loupe-db.php';
 		require_once WP_LOUPE_PATH . 'includes/class-wp-loupe-utils.php';
 		require_once WP_LOUPE_PATH . 'includes/class-wp-loupe-settings.php';
-
-
 	}
 
 	/**
@@ -54,7 +52,7 @@ class WP_Loupe_Loader {
 	private function setup_post_types() {
 		add_filter( 'wp_loupe_post_types', array( $this, 'filter_post_types' ) );
 		$this->post_types = apply_filters( 'wp_loupe_post_types', array( 'post', 'page' ) );
-		WP_Loupe_Utils::dump( [ 'post_types', $this->post_types ] );
+		
 	}
 
 	/**
@@ -63,8 +61,7 @@ class WP_Loupe_Loader {
 	 * @return void
 	 */
 	private function init_components() {
-		new WP_Loupe_Updater( WP_LOUPE_FILE );
-
+		new WP_Loupe_Updater();
 		$this->search  = new WP_Loupe_Search( $this->post_types );
 		$this->indexer = new WP_Loupe_Indexer( $this->post_types );
 	}

--- a/includes/class-wp-loupe-schema-manager.php
+++ b/includes/class-wp-loupe-schema-manager.php
@@ -69,7 +69,7 @@ class WP_Loupe_Schema_Manager {
 
 		$processed_fields = [];
 		foreach ( $schema as $field => $settings ) {
-			WP_Loupe_Utils::dump( [ 'settings >' . $field, $settings ] );
+			
 			$processed_fields[] = $this->process_field( $field, $settings, $type );
 		}
 

--- a/includes/class-wp-loupe-search.php
+++ b/includes/class-wp-loupe-search.php
@@ -57,7 +57,7 @@ class WP_Loupe_Search {
 		$query->set( 'post_type', $this->post_types );
 		$search_term = $this->prepare_search_term( $query->query_vars[ 'search_terms' ] );
 		$hits        = $this->search( $search_term );
-		WP_Loupe_Utils::dump( [ 'hits', $hits ] );
+		
 
 		// Get all search results first
 		$all_posts               = $this->create_post_objects( $hits );

--- a/includes/class-wp-loupe-updater.php
+++ b/includes/class-wp-loupe-updater.php
@@ -21,7 +21,7 @@ class WP_Loupe_Updater {
 	/**
 	 * @var string Main plugin file path
 	 */
-	private $plugin_file;
+	private $plugin_file = WP_LOUPE_FILE;
 
 	/**
 	 * @var string Plugin slug
@@ -33,8 +33,7 @@ class WP_Loupe_Updater {
 	 * 
 	 * @param string $plugin_file Main plugin file path
 	 */
-	public function __construct( $plugin_file ) {
-		$this->plugin_file = $plugin_file;
+	public function __construct() {
 		$this->init();
 	}
 

--- a/includes/class-wp-loupe-utils.php
+++ b/includes/class-wp-loupe-utils.php
@@ -111,10 +111,10 @@ class WP_Loupe_Utils {
 			'offset' => 0,
 			'number' => 1000,
 		) );
-		WP_Loupe_Utils::dump( [ 'matches', $matches ] );
+		
 		foreach ( $matches as $match ) {
 			$transient_name = str_replace( '_transient_', '', $match->option_name );
-			WP_Loupe_Utils::dump( [ 'transient_name', $transient_name ] );
+			
 			delete_transient( $transient_name );
 		}
 	}

--- a/includes/trait-wp-loupe-shared.php
+++ b/includes/trait-wp-loupe-shared.php
@@ -40,9 +40,9 @@ trait WP_Loupe_Shared {
 			return "{$field[ 'field' ]}";
 		}, $sortable );
 
-		WP_Loupe_Utils::dump( [ 'filterable', $filterable ] );
-		WP_Loupe_Utils::dump( [ 'sortable', $sortable ] );
-		WP_Loupe_Utils::dump( [ 'indexable', $indexable ] );
+		
+		
+		
 		$configuration = Configuration::create()
 			->withPrimaryKey( 'id' )
 			->withSearchableAttributes( $indexable )

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-loupe",
-	"version": "0.1.5",
+	"version": "0.1.6",
 	"description": "Enhance the search functionality of your WordPress site with WP Loupe.",
 	"main": "index.js",
 	"scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: search, loupe, posts, pages, custom post types, typo-tolerant, fast search
 Requires at least: 6.3
 Requires PHP: 8.1
 Tested up to: 6.7
-Stable tag: 0.1.5
+Stable tag: 0.1.6
 Donate link: https://paypal.me/PerSoderlind
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/wp-loupe.php
+++ b/wp-loupe.php
@@ -10,7 +10,7 @@
  * Plugin Name:       WP Loupe
  * Plugin URI:        https://github.com/soderlind/wp-loupe
  * Description:       Enhance the search functionality of your WordPress site with WP Loupe.
- * Version:           0.1.5
+ * Version:           0.1.6
  * Author:            Per Soderlind
  * Author URI:        https://soderlind.no
  * License:           GPL-2.0+


### PR DESCRIPTION
This pull request includes several updates and improvements to the WP Loupe plugin. The most important changes involve version updates, code cleanup, and minor refactoring.

Version updates:
* Updated the version number to `0.1.6` in `composer.json`, `package.json`, `readme.txt`, and `wp-loupe.php` to reflect the new release. [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L6-R6) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[3]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L7-R7) [[4]](diffhunk://#diff-0748dd44810f34aab89de4f1c30508f3daf827a816ae5e86010cb5bb0e845cccL13-R13)

Code cleanup:
* Removed unnecessary `WP_Loupe_Utils::dump` debug statements from various functions to clean up the code. [[1]](diffhunk://#diff-05a01153dae4d937761043e52e0f0b5c2b05742142885bab821375bb539f148cL138-R138) [[2]](diffhunk://#diff-d84e436ea0b5f8bacd581539b17867fbcf4998a3d98b9a3f4ab013af45e21fe4L57-R55) [[3]](diffhunk://#diff-5ce102602bdf4b1091c82da8885fa0698e8c602c6ee436bbbd43460a964c6c97L72-R72) [[4]](diffhunk://#diff-8611c0333690318dcdfb5aaf2f2d1aaf49c104f166d9abf872255cb053ddfee8L60-R60) [[5]](diffhunk://#diff-387a78d6ac7bd584490afcce9f620c93444effee73f3e120aa74f67a5562956aL114-R117) [[6]](diffhunk://#diff-eb2e83378c7dc27cd3dce614fb1135a28a8b0be20b9a44e7c4e1a4b652b55adfL43-R45)

Minor refactoring:
* Modified the `WP_Loupe_Updater` class to no longer require a `plugin_file` parameter in the constructor, using a default value instead. [[1]](diffhunk://#diff-08862678880cb2c1e628a4e8048fd9cfef32d9612b4fa0e90354680668092cc5L24-R24) [[2]](diffhunk://#diff-08862678880cb2c1e628a4e8048fd9cfef32d9612b4fa0e90354680668092cc5L36-R36)

Housekeeping:
* Added a housekeeping section to the `CHANGELOG.md` file for version `0.1.6`.