### PR TITLE
Bump version to 0.2.2; enhance field indexing and selection behavior …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.2] - 2025-03-08
+
+### Changed
+
+- Modified field indexing to only include explicitly selected fields in settings
+- Updated schema manager to respect indexable field settings
+- Improved field selection behavior in admin interface
+
 ## [0.2.1] - 2025-03-07
 
 ### Added
@@ -244,3 +252,4 @@ All notable changes to this project will be documented in this file.
 [0.1.7]: https://github.com/soderlind/wp-loupe/releases/tag/0.1.7
 [0.2.0]: https://github.com/soderlind/wp-loupe/releases/tag/0.2.0
 [0.2.1]: https://github.com/soderlind/wp-loupe/releases/tag/0.2.1
+[0.2.2]: https://github.com/soderlind/wp-loupe/releases/tag/0.2.2

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"type": "wordpress-plugin",
 	"description": "Search engine for WordPress. It uses the Loupe search engine to create a search index for your posts and pages and to search the index.",
 	"homepage": "https://github.com/soderlind/wp-loupe",
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"license": "GPL-2.0+",
 	"authors": [
 		{

--- a/includes/class-wp-loupe-factory.php
+++ b/includes/class-wp-loupe-factory.php
@@ -24,6 +24,7 @@ class WP_Loupe_Factory {
 	public static function create_loupe_instance( string $post_type, string $lang, WP_Loupe_DB $db ): \Loupe\Loupe\Loupe {
 		$schema_manager = WP_Loupe_Schema_Manager::get_instance();
 		$schema = $schema_manager->get_schema_for_post_type( $post_type );
+		$saved_fields = get_option('wp_loupe_fields', []);
 
 		// Get all fields in one pass and extract what we need
 		$fields = [ 
@@ -34,29 +35,39 @@ class WP_Loupe_Factory {
 
 		// Process all fields in a single loop instead of multiple calls
 		foreach ( $schema as $field_name => $settings ) {
-			// Skip fields not marked as indexable
-			if ( ! is_array( $settings ) || empty( $settings['indexable'] ) ) {
+			// Skip fields that aren't marked as indexable in settings or via post_date special case
+			if ( ! is_array( $settings ) || 
+				(!$settings['indexable'] && $field_name !== 'post_date') ||
+				($field_name !== 'post_date' && isset($saved_fields[$post_type][$field_name]) && !$saved_fields[$post_type][$field_name]['indexable'])) {
 				continue;
 			}
 
-			 // Remove table aliases from field name (e.g., "d.post_title" becomes "post_title")
+			// Remove table aliases from field name (e.g., "d.post_title" becomes "post_title")
 			$clean_field_name = preg_replace('/^[a-zA-Z]+\./', '', $field_name);
 
-			 // Add to indexable fields with weight
+			// Add to indexable fields with weight
 			$fields['indexable'][] = [ 
 				'field'  => $clean_field_name,
 				'weight' => $settings['weight'] ?? 1.0,
 			];
 
-			 // Add to filterable if explicitly set
+			// Add to filterable if explicitly set
 			if ( ! empty( $settings['filterable'] ) ) {
 				$fields['filterable'][] = $clean_field_name;
 			}
 
-			 // Add to sortable if explicitly set
+			// Add to sortable if explicitly set
 			if ( ! empty( $settings['sortable'] ) ) {
 				$fields['sortable'][] = $clean_field_name;
 			}
+		 }
+
+		 // Ensure post_date is always included in indexable fields if not already present
+		if (!in_array('post_date', array_column($fields['indexable'], 'field'))) {
+			$fields['indexable'][] = [
+				'field' => 'post_date',
+				'weight' => 1.0
+			];
 		}
 
 		// Sort indexable fields by weight once

--- a/includes/class-wp-loupe-settings.php
+++ b/includes/class-wp-loupe-settings.php
@@ -281,33 +281,36 @@ class WPLoupe_Settings_Page {
 	}
 
 	public function sanitize_fields_settings($input) {
-		if (!is_array($input)) {
-			return [];
-		}
+        if (!is_array($input)) {
+            return [];
+        }
 
-		$sanitized = [];
-		foreach ($input as $post_type => $fields) {
-			if (!is_array($fields)) continue;
+        $sanitized = [];
+        foreach ($input as $post_type => $fields) {
+            if (!is_array($fields)) continue;
 
-			foreach ($fields as $field_key => $settings) {
-				$sanitized[$post_type][$field_key] = [
-					 'indexable' => !empty($settings['indexable']),
-					'weight' => isset($settings['weight']) ? 
-						floatval($settings['weight']) : 1.0,
-					'filterable' => !empty($settings['filterable']),
-					'sortable' => !empty($settings['sortable']),
-					'sort_direction' => isset($settings['sort_direction']) && 
-						in_array($settings['sort_direction'], ['asc', 'desc']) ? 
-						$settings['sort_direction'] : 'desc'
-				];
-			}
-		}
+            foreach ($fields as $field_key => $settings) {
+                // Only include the field if it's explicitly marked as indexable
+                if (!empty($settings['indexable'])) {
+                    $sanitized[$post_type][$field_key] = [
+                        'indexable' => true,
+                        'weight' => isset($settings['weight']) ? 
+                            floatval($settings['weight']) : 1.0,
+                        'filterable' => !empty($settings['filterable']),
+                        'sortable' => !empty($settings['sortable']),
+                        'sort_direction' => isset($settings['sort_direction']) && 
+                            in_array($settings['sort_direction'], ['asc', 'desc']) ? 
+                            $settings['sort_direction'] : 'desc'
+                    ];
+                }
+            }
+        }
 
-		// Clear schema cache when settings are updated
-		WP_Loupe_Schema_Manager::get_instance()->clear_cache();
-		
-		return $sanitized;
-	}
+        // Clear schema cache when settings are updated
+        WP_Loupe_Schema_Manager::get_instance()->clear_cache();
+        
+        return $sanitized;
+    }
 
 	/**
 	 * Enqueue Select2.

--- a/lib/css/admin.css
+++ b/lib/css/admin.css
@@ -16,6 +16,10 @@
 	padding: 8px;
 }
 
+.wp-loupe-fields-table td:first-child {
+	width: 15%;
+}
+
 .wp-loupe-fields-table td {
 	padding: 8px;
 	vertical-align: middle;

--- a/lib/js/admin.js
+++ b/lib/js/admin.js
@@ -91,13 +91,13 @@ document.addEventListener('DOMContentLoaded', () => {
             labelCell.appendChild(label);
             row.appendChild(labelCell);
             
-            // Indexable checkbox - always checked and disabled for date fields
+            // Indexable checkbox
             const indexableCell = document.createElement('td');
             const indexableInput = document.createElement('input');
             indexableInput.type = 'checkbox';
             indexableInput.name = `wp_loupe_fields[${postType}][${fieldKey}][indexable]`;
             indexableInput.value = '1';
-            indexableInput.checked = isProtected || isDateField || savedFieldSettings.indexable !== false;
+            indexableInput.checked = isProtected || isDateField || savedFieldSettings.indexable === true;
             indexableInput.disabled = isProtected || isDateField;
             indexableCell.appendChild(indexableInput);
             row.appendChild(indexableCell);
@@ -111,6 +111,7 @@ document.addEventListener('DOMContentLoaded', () => {
             weightInput.name = `wp_loupe_fields[${postType}][${fieldKey}][weight]`;
             weightInput.value = savedFieldSettings.weight || (isTitle ? '2.0' : '1.0');
             weightInput.className = 'small-text';
+            weightInput.disabled = !indexableInput.checked;
             weightCell.appendChild(weightInput);
             row.appendChild(weightCell);
             
@@ -121,6 +122,7 @@ document.addEventListener('DOMContentLoaded', () => {
             filterableInput.name = `wp_loupe_fields[${postType}][${fieldKey}][filterable]`;
             filterableInput.value = '1';
             filterableInput.checked = isDateField ? true : savedFieldSettings.filterable;
+            filterableInput.disabled = !indexableInput.checked;
             filterableCell.appendChild(filterableInput);
             row.appendChild(filterableCell);
             
@@ -132,6 +134,7 @@ document.addEventListener('DOMContentLoaded', () => {
             sortableInput.value = '1';
             sortableInput.className = 'wp-loupe-sortable-toggle';
             sortableInput.checked = isDateField ? true : savedFieldSettings.sortable;
+            sortableInput.disabled = !indexableInput.checked;
             sortableCell.appendChild(sortableInput);
             row.appendChild(sortableCell);
             
@@ -140,7 +143,7 @@ document.addEventListener('DOMContentLoaded', () => {
             const directionSelect = document.createElement('select');
             directionSelect.name = `wp_loupe_fields[${postType}][${fieldKey}][sort_direction]`;
             directionSelect.className = 'wp-loupe-sort-direction';
-            directionSelect.disabled = !sortableInput.checked;
+            directionSelect.disabled = !sortableInput.checked || !indexableInput.checked;
             
             const ascOption = document.createElement('option');
             ascOption.value = 'asc';
@@ -156,6 +159,15 @@ document.addEventListener('DOMContentLoaded', () => {
             directionSelect.appendChild(descOption);
             directionCell.appendChild(directionSelect);
             row.appendChild(directionCell);
+
+            // Add event listener for indexable checkbox
+            indexableInput.addEventListener('change', () => {
+                const isChecked = indexableInput.checked;
+                weightInput.disabled = !isChecked;
+                filterableInput.disabled = !isChecked;
+                sortableInput.disabled = !isChecked;
+                directionSelect.disabled = !isChecked || !sortableInput.checked;
+            });
             
             tbody.appendChild(row);
         });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-loupe",
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"description": "Enhance the search functionality of your WordPress site with WP Loupe.",
 	"main": "index.js",
 	"scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: search, loupe, posts, pages, custom post types, typo-tolerant, fast search
 Requires at least: 6.3
 Requires PHP: 8.1
 Tested up to: 6.7
-Stable tag: 0.2.1
+Stable tag: 0.2.2
 Donate link: https://paypal.me/PerSoderlind
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -104,6 +104,11 @@ Default: Removes HTML comments
 For usage examples, see the plugin's README.md file.
 
 == Changelog ==
+
+= 0.2.2 =
+* Changed: Modified field indexing to only include explicitly selected fields in settings
+* Changed: Updated schema manager to respect indexable field settings
+* Changed: Improved field selection behavior in admin interface
 
 = 0.2.1 =
 * Added translation support for admin interface

--- a/wp-loupe.php
+++ b/wp-loupe.php
@@ -10,7 +10,7 @@
  * Plugin Name:       WP Loupe
  * Plugin URI:        https://github.com/soderlind/wp-loupe
  * Description:       Enhance the search functionality of your WordPress site with WP Loupe.
- * Version:           0.2.1
+ * Version:           0.2.2
  * Author:            Per Soderlind
  * Author URI:        https://soderlind.no
  * License:           GPL-2.0+


### PR DESCRIPTION
This pull request includes several changes to improve field indexing and update the version to 0.2.2. The most important changes focus on modifying how fields are indexed and enhancing the admin interface for better field selection behavior.

### Field Indexing Improvements:
* Modified field indexing to only include explicitly selected fields in settings (`CHANGELOG.md`, `includes/class-wp-loupe-factory.php`, `includes/class-wp-loupe-schema-manager.php`, `includes/class-wp-loupe-settings.php`) [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R12) [[2]](diffhunk://#diff-be72c765f4d27833a99b5bfa75f53dfb5067db9783808368cb4e28c7f8b2de12L37-R56) [[3]](diffhunk://#diff-5ce102602bdf4b1091c82da8885fa0698e8c602c6ee436bbbd43460a964c6c97L108-R113) [[4]](diffhunk://#diff-9e1309b77c531cf40caccb09d900900e0773ed33689bd23cfcbaad8f4d1a9facR293-R296).
* Updated schema manager to respect indexable field settings (`includes/class-wp-loupe-schema-manager.php`).

### Admin Interface Enhancements:
* Improved field selection behavior in the admin interface (`lib/css/admin.css`, `lib/js/admin.js`) [[1]](diffhunk://#diff-da750feb3c7169627c870574f73ab1bb3efbbe5972b8afb772c0dada2a525ccfR19-R22) [[2]](diffhunk://#diff-300efaf02779f9ccbdfa8b4d7b521cdeeac346aac8b0762adfc61e00bb8100d2L94-R100).

### Version Updates:
* Updated version to 0.2.2 in various files (`composer.json`, `package.json`, `readme.txt`, `wp-loupe.php`) [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L6-R6) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[3]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L7-R7) [[4]](diffhunk://#diff-0748dd44810f34aab89de4f1c30508f3daf827a816ae5e86010cb5bb0e845cccL13-R13).

### Documentation:
* Added changelog entries for version 0.2.2 (`CHANGELOG.md`, `readme.txt`) [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R12) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R108-R112).