### PR TITLE
Fx `Tested up to` value in readme.txt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.2] - 2023-03-12
+
+### Fixed
+- In readme.txt, update the `Tested up to` value to 6.7
+
 ## [0.3.1] - 2023-03-12
 
 ### Fixed
@@ -288,3 +293,5 @@ All notable changes to this project will be documented in this file.
 [0.2.2]: https://github.com/soderlind/wp-loupe/releases/tag/0.2.2
 [0.2.3]: https://github.com/soderlind/wp-loupe/releases/tag/0.2.3
 [0.3.0]: https://github.com/soderlind/wp-loupe/releases/tag/0.3.0
+[0.3.1]: https://github.com/soderlind/wp-loupe/releases/tag/0.3.1
+[0.3.2]: https://github.com/soderlind/wp-loupe/releases/tag/0.3.2

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"type": "wordpress-plugin",
 	"description": "Search engine for WordPress. It uses the Loupe search engine to create a search index for your posts and pages and to search the index.",
 	"homepage": "https://github.com/soderlind/wp-loupe",
-	"version": "0.3.1",
+	"version": "0.3.2",
 	"license": "GPL-2.0+",
 	"authors": [
 		{

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-loupe",
-	"version": "0.3.1",
+	"version": "0.3.2",
 	"description": "Enhance the search functionality of your WordPress site with WP Loupe.",
 	"main": "index.js",
 	"scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: persoderlind
 Tags: search, full-text search, relevance
 Requires at least: 5.6
-Tested up to: 6.2
-Stable tag: 0.3.1
+Tested up to: 6.7
+Stable tag: 0.3.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -101,6 +101,9 @@ Customizes the schema for a post type.
 For usage examples, see the [filter documentation at GitHub](https://github.com/soderlind/wp-loupe?tab=readme-ov-file#filters).
 
 == Changelog ==
+
+= 0.3.2 =
+* Fixed: In readme.txt, update the `Tested up to` value to 6.7
 
 = 0.3.1 =
 * Bug fix: Non-scalar fields no longer get selected by default for sorting when adding a new post type

--- a/wp-loupe.php
+++ b/wp-loupe.php
@@ -10,7 +10,7 @@
  * Plugin Name:       WP Loupe
  * Plugin URI:        https://github.com/soderlind/wp-loupe
  * Description:       Enhance the search functionality of your WordPress site with WP Loupe.
- * Version:           0.3.1
+ * Version:           0.3.2
  * Author:            Per Soderlind
  * Author URI:        https://soderlind.no
  * License:           GPL-2.0+


### PR DESCRIPTION
This pull request includes version updates and a fix for the `Tested up to` value in the `readme.txt` file. The most important changes include updating version numbers across multiple files and documenting the changes in the `CHANGELOG.md`.

Version updates:

* [`composer.json`](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L6-R6): Updated the version from `0.3.1` to `0.3.2`.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3): Updated the version from `0.3.1` to `0.3.2`.
* [`wp-loupe.php`](diffhunk://#diff-0748dd44810f34aab89de4f1c30508f3daf827a816ae5e86010cb5bb0e845cccL13-R13): Updated the version from `0.3.1` to `0.3.2`.

Documentation updates:

* [`readme.txt`](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L5-R6): Updated the `Tested up to` value to 6.7 and the stable tag to `0.3.2`.
* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R9): Added entries for version `0.3.2`, including the fix for the `Tested up to` value. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR5-R9) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR296-R297)