### PR TITLE
Add post type validation in delete methods of WP_Loupe_Indexer class, fix #50

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.2] - 2023-03-17
+### Fixed
+- Customizer settings not being saved
+
+
 ## [0.4.1] - 2023-03-13
 ### Changed
 - Update advanced settings documentation in README.md
@@ -319,3 +324,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.3.2]: https://github.com/soderlind/wp-loupe/releases/tag/0.3.2
 [0.4.0]: https://github.com/soderlind/wp-loupe/releases/tag/0.4.0
 [0.4.1]: https://github.com/soderlind/wp-loupe/releases/tag/0.4.1
+[0.4.2]: https://github.com/soderlind/wp-loupe/releases/tag/0.4.2

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"type": "wordpress-plugin",
 	"description": "Search engine for WordPress. It uses the Loupe search engine to create a search index for your posts and pages and to search the index.",
 	"homepage": "https://github.com/soderlind/wp-loupe",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"license": "GPL-2.0+",
 	"authors": [
 		{

--- a/includes/class-wp-loupe-indexer.php
+++ b/includes/class-wp-loupe-indexer.php
@@ -125,6 +125,9 @@ class WP_Loupe_Indexer {
      */
     private function delete( int $post_id ): void {
         $post_type = get_post_type( $post_id );
+		if ( ! in_array( $post_type, $this->post_types, true ) ) {
+			return;
+		}
         $loupe     = $this->loupe[ $post_type ];
         $loupe->deleteDocument( $post_id );
     }
@@ -136,6 +139,9 @@ class WP_Loupe_Indexer {
      */
     private function delete_many( array $post_ids ): void {
         $post_type = get_post_type( $post_ids[ 0 ] );
+		if ( ! in_array( $post_type, $this->post_types, true ) ) {
+			return;
+		}
         $loupe     = $this->loupe[ $post_type ];
         $loupe->deleteDocuments( $post_ids );
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-loupe",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"description": "Enhance the search functionality of your WordPress site with WP Loupe.",
 	"main": "index.js",
 	"scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: persoderlind
 Tags: search, full-text search, relevance
 Requires at least: 5.6
 Tested up to: 6.7
-Stable tag: 0.4.1
+Stable tag: 0.4.2
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -101,6 +101,9 @@ Customizes the schema for a post type.
 For usage examples, see the [filter documentation at GitHub](https://github.com/soderlind/wp-loupe?tab=readme-ov-file#filters).
 
 == Changelog ==
+
+= 0.4.2 =
+* Customizer settings not being saved
 
 = 0.4.1 =
 * Update advanced settings documentation in README.md

--- a/wp-loupe.php
+++ b/wp-loupe.php
@@ -10,7 +10,7 @@
  * Plugin Name:       WP Loupe
  * Plugin URI:        https://github.com/soderlind/wp-loupe
  * Description:       Enhance the search functionality of your WordPress site with WP Loupe.
- * Version:           0.4.1
+ * Version:           0.4.2
  * Author:            Per Soderlind
  * Author URI:        https://soderlind.no
  * License:           GPL-2.0+


### PR DESCRIPTION
This pull request includes version updates and bug fixes for the WP Loupe project. The most important changes include updating the version number to 0.4.2, fixing an issue with customizer settings not being saved, and adding checks to ensure only supported post types are processed.

### Version updates:
* Updated version number to 0.4.2 in `composer.json`, `package.json`, `readme.txt`, and `wp-loupe.php`. [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L6-R6) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[3]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L6-R6) [[4]](diffhunk://#diff-0748dd44810f34aab89de4f1c30508f3daf827a816ae5e86010cb5bb0e845cccL13-R13)

### Bug fixes:
* Fixed customizer settings not being saved. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R12) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6R105-R107)
* Added checks in `delete` and `delete_many` methods to ensure only supported post types are processed in `includes/class-wp-loupe-indexer.php`. [[1]](diffhunk://#diff-05a01153dae4d937761043e52e0f0b5c2b05742142885bab821375bb539f148cR128-R130) [[2]](diffhunk://#diff-05a01153dae4d937761043e52e0f0b5c2b05742142885bab821375bb539f148cR142-R144)

### Documentation updates:
* Added changelog entry for version 0.4.2 in `CHANGELOG.md`. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R12) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR327)