### PR TITLE
Fix/rest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.3] - 2025-09-30
+### Added
+- Copy buttons (with accessibility & status feedback) for manifest and protected resource endpoints in MCP settings
+- Screen-reader friendly live region announcing copy success/failure
+
+### Changed
+- Further refined MCP settings layout; ensured no inline JavaScript remains for endpoint copying
+- Minor wording tweaks in endpoint descriptions for clarity
+
+### Fixed
+- Defensive clipboard fallback path using hidden textarea to support insecure contexts / older browsers
+
+### Notes
+- Small UX iteration; next releases will focus on token issuance improvements & dynamic manifest enrichment
+
 ## [0.5.2] - 2025-09-29
 ### Added
 - Rate limiting settings UI polish (clear separation of anonymous vs authenticated buckets)
@@ -21,21 +36,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Notes
 - Prepares groundwork for broader rate-limit configurability and future manifest expansion
-
-## [0.5.3] - 2025-09-30
-### Added
-- Copy buttons (with accessibility & status feedback) for manifest and protected resource endpoints in MCP settings
-- Screen-reader friendly live region announcing copy success/failure
-
-### Changed
-- Further refined MCP settings layout; ensured no inline JavaScript remains for endpoint copying
-- Minor wording tweaks in endpoint descriptions for clarity
-
-### Fixed
-- Defensive clipboard fallback path using hidden textarea to support insecure contexts / older browsers
-
-### Notes
-- Small UX iteration; next releases will focus on token issuance improvements & dynamic manifest enrichment
 
 ## [0.5.1] - 2025-09-29
 ### Added
@@ -405,3 +405,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.4.0]: https://github.com/soderlind/wp-loupe/releases/tag/0.4.0
 [0.4.1]: https://github.com/soderlind/wp-loupe/releases/tag/0.4.1
 [0.4.2]: https://github.com/soderlind/wp-loupe/releases/tag/0.4.2
+[0.5.0]: https://github.com/soderlind/wp-loupe/releases/tag/0.5.0
+[0.5.1]: https://github.com/soderlind/wp-loupe/releases/tag/0.5.1
+[0.5.2]: https://github.com/soderlind/wp-loupe/releases/tag/0.5.2
+[0.5.3]: https://github.com/soderlind/wp-loupe/releases/tag/0.5.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.5.2] - 2025-09-29
 ### Added
-- (Placeholder) Configurable rate limiting UI refinements (anonymous vs authenticated)
+- Rate limiting settings UI polish (clear separation of anonymous vs authenticated buckets)
+- Discovery endpoints surfaced in settings (manifest & protected resource) for easier client setup
 
 ### Changed
-- (Placeholder) Internal adjustments post 0.5.1 token UI
+- Removed POST `/commands` endpoint from the public endpoint list to avoid method confusion
+- Centralized endpoint copy behavior into `admin.js` (removed inline script)
+- Improved accessibility: added aria-live region for copy feedback
+
+### Fixed
+- Ensured `/.well-known/mcp.json` manifest reliably returns JSON once MCP enabled (rewrite + fallback logic)
+- Clipboard copy fallback for browsers or contexts without `navigator.clipboard`
 
 ### Notes
-- Draft section for upcoming improvements
+- Prepares groundwork for broader rate-limit configurability and future manifest expansion
+
+## [0.5.3] - 2025-09-30
+### Added
+- Copy buttons (with accessibility & status feedback) for manifest and protected resource endpoints in MCP settings
+- Screen-reader friendly live region announcing copy success/failure
+
+### Changed
+- Further refined MCP settings layout; ensured no inline JavaScript remains for endpoint copying
+- Minor wording tweaks in endpoint descriptions for clarity
+
+### Fixed
+- Defensive clipboard fallback path using hidden textarea to support insecure contexts / older browsers
+
+### Notes
+- Small UX iteration; next releases will focus on token issuance improvements & dynamic manifest enrichment
 
 ## [0.5.1] - 2025-09-29
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
 	"type": "wordpress-plugin",
 	"description": "Search engine for WordPress. It uses the Loupe search engine to create a search index for your posts and pages and to search the index.",
 	"homepage": "https://github.com/soderlind/wp-loupe",
-	"version": "0.5.2",
+	"version": "0.5.3",
 	"license": "GPL-2.0+",
 	"authors": [
 		{

--- a/includes/class-wp-loupe-settings.php
+++ b/includes/class-wp-loupe-settings.php
@@ -866,9 +866,20 @@ class WPLoupe_Settings_Page {
 								<strong
 									style="display:block;margin-bottom:6px;"><?php esc_html_e( 'Active Endpoints', 'wp-loupe' ); ?></strong>
 								<ul style="margin:0 0 4px 18px;list-style:disc;">
-									<li><code><?php echo esc_html( home_url( '/.well-known/mcp.json' ) ); ?></code></li>
-									<li><code><?php echo esc_html( rest_url( 'wp-loupe-mcp/v1/commands' ) ); ?></code></li>
+									<li><code><?php echo esc_html( home_url( '/.well-known/mcp.json' ) ); ?></code> <button
+											type="button" class="button button-small wp-loupe-copy-endpoint"
+											data-copy="<?php echo esc_attr( home_url( '/.well-known/mcp.json' ) ); ?>"
+											aria-label="<?php esc_attr_e( 'Copy manifest URL', 'wp-loupe' ); ?>"
+											style="margin-left:6px;">&nbsp;<?php esc_html_e( 'Copy', 'wp-loupe' ); ?>&nbsp;</button>
+									</li>
+									<li><code><?php echo esc_html( home_url( '/.well-known/oauth-protected-resource' ) ); ?></code>
+										<button type="button" class="button button-small wp-loupe-copy-endpoint"
+											data-copy="<?php echo esc_attr( home_url( '/.well-known/oauth-protected-resource' ) ); ?>"
+											aria-label="<?php esc_attr_e( 'Copy protected resource URL', 'wp-loupe' ); ?>"
+											style="margin-left:6px;">&nbsp;<?php esc_html_e( 'Copy', 'wp-loupe' ); ?>&nbsp;</button>
+									</li>
 								</ul>
+								<div id="wp-loupe-copy-live" class="screen-reader-text" aria-live="polite" role="status"></div>
 								<p class="description" style="margin:4px 0 0;">
 									<?php esc_html_e( 'Provide these to MCP-compatible clients. Rate limits and token scopes still apply.', 'wp-loupe' ); ?>
 								</p>

--- a/info.json
+++ b/info.json
@@ -1,7 +1,7 @@
 {
     "name": "WP Loupe",
     "slug": "wp-loupe",
-    "version": "0.5.2",
+    "version": "0.5.3",
     "download_url": "https://github.com/soderlind/wp-loupe/releases/latest/download/wp-loupe.zip",
     "tested": "6.7",
     "requires": "6.3",

--- a/lib/js/admin.js
+++ b/lib/js/admin.js
@@ -654,6 +654,67 @@ class WpLoupeFieldManager {
 // Initialize the field manager when the DOM is loaded
 document.addEventListener('DOMContentLoaded', () => {
     new WpLoupeFieldManager();
+
+    // Endpoint copy buttons (moved from inline script in settings template)
+    (function(){
+        const liveRegionId = 'wp-loupe-copy-live';
+        let live = document.getElementById(liveRegionId);
+        if(!live){
+            live = document.createElement('div');
+            live.id = liveRegionId;
+            live.className = 'screen-reader-text';
+            live.setAttribute('role','status');
+            live.setAttribute('aria-live','polite');
+            document.body.appendChild(live);
+        }
+        document.addEventListener('click', function(e){
+            const btn = e.target.closest('.wp-loupe-copy-endpoint');
+            if(!btn) return;
+            const val = btn.getAttribute('data-copy');
+            if(!val) return;
+            const originalHTML = btn.innerHTML;
+            const __ = (window.wp && wp.i18n && wp.i18n.__) ? wp.i18n.__ : (s=>s);
+            const copiedLabel = __('Copied','wp-loupe');
+            const failedLabel = __('Copy failed','wp-loupe');
+
+            function acknowledge(success){
+                btn.classList.add('wp-loupe-copied');
+                btn.innerHTML = success ? copiedLabel : failedLabel;
+                live.textContent = (success ? copiedLabel : failedLabel) + (success ? ': ' + val : '');
+                setTimeout(function(){
+                    btn.innerHTML = originalHTML;
+                    btn.classList.remove('wp-loupe-copied');
+                },1600);
+            }
+
+            // Modern API path
+            if(navigator.clipboard && navigator.clipboard.writeText){
+                navigator.clipboard.writeText(val).then(function(){
+                    acknowledge(true);
+                }).catch(function(){
+                    // Fallback to legacy method
+                    const ta = document.createElement('textarea');
+                    ta.value = val;
+                    ta.style.position='fixed';
+                    ta.style.opacity='0';
+                    document.body.appendChild(ta);
+                    ta.select();
+                    try { document.execCommand('copy') ? acknowledge(true) : acknowledge(false); } catch(err){ acknowledge(false); }
+                    document.body.removeChild(ta);
+                });
+            } else {
+                // Legacy fallback immediately
+                const ta = document.createElement('textarea');
+                ta.value = val;
+                ta.style.position='fixed';
+                ta.style.opacity='0';
+                document.body.appendChild(ta);
+                ta.select();
+                try { document.execCommand('copy') ? acknowledge(true) : acknowledge(false); } catch(err){ acknowledge(false); }
+                document.body.removeChild(ta);
+            }
+        });
+    })();
 });
 
 // Add DOM utility functions

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-loupe",
-	"version": "0.4.3",
+	"version": "0.5.3",
 	"description": "Enhance the search functionality of your WordPress site with WP Loupe.",
 	"main": "index.js",
 	"scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -158,7 +158,22 @@ Yes, you can select which post types to include in the Settings page or via filt
 
 == Changelog ==
 
-== Changelog ==
+= 0.5.3 =
+* Added: Copy buttons (with accessible live feedback) for MCP manifest and protected resource endpoints.
+* Added: Aria-live region and translatable status messages for copy success/failure.
+* Changed: Removed inline JavaScript for endpoint copying; logic centralized in `admin.js`.
+* Fixed: Clipboard fallback for browsers without `navigator.clipboard` support.
+* Changed: Minor wording clarity improvements in endpoint descriptions.
+* Note: Small UX iteration paving the way for richer manifest metadata.
+
+= 0.5.2 =
+* Added: Settings surfacing discovery endpoints (manifest & protected resource) for MCP clients.
+* Added: Accessibility improvements groundwork (live region placeholder) before 0.5.3 enhancements.
+* Changed: Removed POST `/commands` from visible endpoint list (method clarity).
+* Fixed: Ensured reliable JSON output for `/.well-known/mcp.json` (rewrite + fallback path).
+* Fixed: Clipboard copy resilience improvements (initial implementation) preparing for 0.5.3.
+* I18n: Regenerated `wp-loupe.pot` with new MCP strings and translator comments.
+* Note: Internal rate-limit option polish and manifest stability adjustments.
 
 = 0.5.1 =
 * UI: Wrapped MCP token table in panel and standardized max-width (840px)
@@ -171,8 +186,6 @@ Yes, you can select which post types to include in the Settings page or via filt
 = 0.5.0 =
 * Initial MCP integration (preview): discovery manifest, commands, rate limiting, scoped tokens, pagination security
 * Requires PHP 8.3+ and Loupe 0.12.13
-
-== Upgrade Notice ==
 
 = 0.5.0 =
 Introduces optional MCP (Model Context Protocol) server (disabled by default). After upgrading:

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: search, full-text search, relevance, typo-tolerant, fast search, search en
 Requires at least: 6.3
 Tested up to: 6.7
 Requires PHP: 8.3
-Stable tag: 0.5.2
+Stable tag: 0.5.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Donate link: https://paypal.me/PerSoderlind

--- a/wp-loupe.php
+++ b/wp-loupe.php
@@ -10,7 +10,7 @@
  * Plugin Name:       WP Loupe
  * Plugin URI:        https://github.com/soderlind/wp-loupe
  * Description:       Enhance the search functionality of your WordPress site with WP Loupe.
- * Version:           0.5.2
+ * Version:           0.5.3
  * Author:            Per Soderlind
  * Author URI:        https://soderlind.no
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ define( 'WP_LOUPE_PATH', plugin_dir_path( WP_LOUPE_FILE ) );
 define( 'WP_LOUPE_URL', plugin_dir_url( WP_LOUPE_FILE ) );
 // MCP related constants (development token & version marker)
 if ( ! defined( 'WP_LOUPE_MCP_VERSION' ) ) {
-	define( 'WP_LOUPE_MCP_VERSION', '0.5.2' );
+	define( 'WP_LOUPE_MCP_VERSION', '0.5.3' );
 }
 // Optional development bearer token for initial implementation (SHOULD be disabled in production)
 if ( ! defined( 'WP_LOUPE_MCP_DEV_TOKEN' ) ) {


### PR DESCRIPTION
This pull request releases version 0.5.3 of WP Loupe, focusing on UX improvements for endpoint copying in the MCP settings. The main enhancements include accessible copy buttons for key endpoints, improved feedback for screen readers, and more robust clipboard handling for older browsers. Minor wording clarifications and layout refinements are also included, along with the usual version bumps across project files.

**MCP Settings UX and Accessibility Improvements**
- Added copy buttons (with accessible status feedback) for the MCP manifest and protected resource endpoints in the settings UI, including a screen-reader friendly live region that announces copy success or failure.
- Centralized and enhanced the endpoint copy logic in `admin.js`, removing all inline JavaScript from the settings template. The new implementation provides both modern clipboard API support and a robust fallback for older browsers or insecure contexts, with translatable status messages and live feedback.

**Wording and Layout Refinements**
- Improved endpoint descriptions for clarity and further refined the MCP settings layout.

**Version Bumps and Changelog**
- Updated version numbers to 0.5.3 in `composer.json`, `package.json`, `info.json`, `wp-loupe.php`, and the MCP version constant. [[1]](diffhunk://#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34L6-R6) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[3]](diffhunk://#diff-08b0decf4d53031c464a737d7b2e4dace532bd33cc54ca6c90c7a2f5d18fbb0bL4-R4) [[4]](diffhunk://#diff-0748dd44810f34aab89de4f1c30508f3daf827a816ae5e86010cb5bb0e845cccL13-R13) [[5]](diffhunk://#diff-0748dd44810f34aab89de4f1c30508f3daf827a816ae5e86010cb5bb0e845cccL38-R38)
- Added a detailed entry for 0.5.3 in `CHANGELOG.md`, including notes on new features, changes, and fixes, and updated the release links. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R38) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR408-R411)
- Updated the stable tag and changelog in `readme.txt` to reflect the new release and summarize the changes. [[1]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L7-R7) [[2]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L161-R176) [[3]](diffhunk://#diff-9e6e4772050998a5c0dc3c61acf3dab0a7e594566171fa5746d6b62f9598efb6L175-L176)