### PR TITLE
chore(deps): fix security vulnerabilities

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -293,16 +293,16 @@
         },
         {
             "name": "loupe/loupe",
-            "version": "0.13.12",
+            "version": "0.13.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/loupe-php/loupe.git",
-                "reference": "1c47333c0843ddbbe2b90211bc9d44c1e516b867"
+                "reference": "2f51f84dd998c7bbfec20259bd97de7d9182710a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/1c47333c0843ddbbe2b90211bc9d44c1e516b867",
-                "reference": "1c47333c0843ddbbe2b90211bc9d44c1e516b867",
+                "url": "https://api.github.com/repos/loupe-php/loupe/zipball/2f51f84dd998c7bbfec20259bd97de7d9182710a",
+                "reference": "2f51f84dd998c7bbfec20259bd97de7d9182710a",
                 "shasum": ""
             },
             "require": {
@@ -312,7 +312,7 @@
                 "ext-mbstring": "*",
                 "ext-pdo_sqlite": "*",
                 "lib-pdo_sqlite-sqlite": ">= 3.35.0",
-                "loupe/matcher": "^0.2.1",
+                "loupe/matcher": "^0.2.2",
                 "mjaschen/phpgeo": "^5.0 || ^6.0",
                 "nitotm/efficient-language-detector": "^3.1",
                 "php": "^8.1",
@@ -348,7 +348,7 @@
             "description": "A full text search engine with tokenization, stemming, typo tolerance, filters and geo support based on only PHP and SQLite",
             "support": {
                 "issues": "https://github.com/loupe-php/loupe/issues",
-                "source": "https://github.com/loupe-php/loupe/tree/0.13.12"
+                "source": "https://github.com/loupe-php/loupe/tree/0.13.13"
             },
             "funding": [
                 {
@@ -356,20 +356,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-07T06:59:06+00:00"
+            "time": "2026-04-15T12:34:09+00:00"
         },
         {
             "name": "loupe/matcher",
-            "version": "0.2.1",
+            "version": "0.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/loupe-php/matcher.git",
-                "reference": "cff4f32b0fda4163a099a435bb3295a790c85261"
+                "reference": "70a1aaf38618b0eb669e93888f86c146c0e88735"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/loupe-php/matcher/zipball/cff4f32b0fda4163a099a435bb3295a790c85261",
-                "reference": "cff4f32b0fda4163a099a435bb3295a790c85261",
+                "url": "https://api.github.com/repos/loupe-php/matcher/zipball/70a1aaf38618b0eb669e93888f86c146c0e88735",
+                "reference": "70a1aaf38618b0eb669e93888f86c146c0e88735",
                 "shasum": ""
             },
             "require": {
@@ -406,7 +406,7 @@
             "description": "Highlight and crop around search terms",
             "support": {
                 "issues": "https://github.com/loupe-php/matcher/issues",
-                "source": "https://github.com/loupe-php/matcher/tree/0.2.1"
+                "source": "https://github.com/loupe-php/matcher/tree/0.2.2"
             },
             "funding": [
                 {
@@ -414,7 +414,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-31T11:31:03+00:00"
+            "time": "2026-04-15T11:58:45+00:00"
         },
         {
             "name": "mjaschen/phpgeo",
@@ -737,7 +737,7 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.34.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
@@ -798,7 +798,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.34.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -1808,16 +1808,16 @@
         },
         {
             "name": "pestphp/pest",
-            "version": "v4.5.0",
+            "version": "v4.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pestphp/pest.git",
-                "reference": "13c322bab3ac4496f89279c0b6ac31b89ce8aa95"
+                "reference": "87db0b484788cfde4778b715bb1fed34133685fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pestphp/pest/zipball/13c322bab3ac4496f89279c0b6ac31b89ce8aa95",
-                "reference": "13c322bab3ac4496f89279c0b6ac31b89ce8aa95",
+                "url": "https://api.github.com/repos/pestphp/pest/zipball/87db0b484788cfde4778b715bb1fed34133685fa",
+                "reference": "87db0b484788cfde4778b715bb1fed34133685fa",
                 "shasum": ""
             },
             "require": {
@@ -1829,12 +1829,12 @@
                 "pestphp/pest-plugin-mutate": "^4.0.1",
                 "pestphp/pest-plugin-profanity": "^4.2.1",
                 "php": "^8.3.0",
-                "phpunit/phpunit": "^12.5.16",
+                "phpunit/phpunit": "^12.5.20",
                 "symfony/process": "^7.4.8|^8.0.8"
             },
             "conflict": {
                 "filp/whoops": "<2.18.3",
-                "phpunit/phpunit": ">12.5.16",
+                "phpunit/phpunit": ">12.5.20",
                 "sebastian/exporter": "<7.0.0",
                 "webmozart/assert": "<1.11.0"
             },
@@ -1909,7 +1909,7 @@
             ],
             "support": {
                 "issues": "https://github.com/pestphp/pest/issues",
-                "source": "https://github.com/pestphp/pest/tree/v4.5.0"
+                "source": "https://github.com/pestphp/pest/tree/v4.6.1"
             },
             "funding": [
                 {
@@ -1921,7 +1921,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-10T19:51:40+00:00"
+            "time": "2026-04-15T16:03:09+00:00"
         },
         {
             "name": "pestphp/pest-plugin",
@@ -2538,16 +2538,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "12.5.5",
+            "version": "12.5.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "a25bde1f8f83849f441ef5713c6466e470872a71"
+                "reference": "876099a072646c7745f673d7aeab5382c4439691"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/a25bde1f8f83849f441ef5713c6466e470872a71",
-                "reference": "a25bde1f8f83849f441ef5713c6466e470872a71",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/876099a072646c7745f673d7aeab5382c4439691",
+                "reference": "876099a072646c7745f673d7aeab5382c4439691",
                 "shasum": ""
             },
             "require": {
@@ -2602,7 +2602,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.5"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.6"
             },
             "funding": [
                 {
@@ -2622,7 +2622,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-13T04:53:32+00:00"
+            "time": "2026-04-15T08:23:17+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -2883,16 +2883,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "12.5.16",
+            "version": "12.5.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "b2429f58ae75cae980b5bb9873abe4de6aac8b58"
+                "reference": "c2364520611caa03567a8a020f2d59f3f90b115a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b2429f58ae75cae980b5bb9873abe4de6aac8b58",
-                "reference": "b2429f58ae75cae980b5bb9873abe4de6aac8b58",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c2364520611caa03567a8a020f2d59f3f90b115a",
+                "reference": "c2364520611caa03567a8a020f2d59f3f90b115a",
                 "shasum": ""
             },
             "require": {
@@ -2906,13 +2906,13 @@
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.3",
-                "phpunit/php-code-coverage": "^12.5.3",
+                "phpunit/php-code-coverage": "^12.5.5",
                 "phpunit/php-file-iterator": "^6.0.1",
                 "phpunit/php-invoker": "^6.0.0",
                 "phpunit/php-text-template": "^5.0.0",
                 "phpunit/php-timer": "^8.0.0",
                 "sebastian/cli-parser": "^4.2.0",
-                "sebastian/comparator": "^7.1.4",
+                "sebastian/comparator": "^7.1.6",
                 "sebastian/diff": "^7.0.0",
                 "sebastian/environment": "^8.0.4",
                 "sebastian/exporter": "^7.0.2",
@@ -2961,7 +2961,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.16"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.20"
             },
             "funding": [
                 {
@@ -2969,7 +2969,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2026-04-03T05:26:42+00:00"
+            "time": "2026-04-15T05:05:59+00:00"
         },
         {
             "name": "psr/container",
@@ -3146,16 +3146,16 @@
         },
         {
             "name": "sebastian/comparator",
-            "version": "7.1.5",
+            "version": "7.1.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "c284f55811f43d555e51e8e5c166ac40d3e33c63"
+                "reference": "c769009dee98f494e0edc3fd4f4087501688f11e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/c284f55811f43d555e51e8e5c166ac40d3e33c63",
-                "reference": "c284f55811f43d555e51e8e5c166ac40d3e33c63",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/c769009dee98f494e0edc3fd4f4087501688f11e",
+                "reference": "c769009dee98f494e0edc3fd4f4087501688f11e",
                 "shasum": ""
             },
             "require": {
@@ -3214,7 +3214,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/7.1.5"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/7.1.6"
             },
             "funding": [
                 {
@@ -3234,7 +3234,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-08T04:43:00+00:00"
+            "time": "2026-04-14T08:23:15+00:00"
         },
         {
             "name": "sebastian/complexity",
@@ -3363,16 +3363,16 @@
         },
         {
             "name": "sebastian/environment",
-            "version": "8.0.4",
+            "version": "8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "7b8842c2d8e85d0c3a5831236bf5869af6ab2a11"
+                "reference": "b121608b28a13f721e76ffbbd386d08eff58f3f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/7b8842c2d8e85d0c3a5831236bf5869af6ab2a11",
-                "reference": "7b8842c2d8e85d0c3a5831236bf5869af6ab2a11",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/b121608b28a13f721e76ffbbd386d08eff58f3f6",
+                "reference": "b121608b28a13f721e76ffbbd386d08eff58f3f6",
                 "shasum": ""
             },
             "require": {
@@ -3387,7 +3387,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "8.0-dev"
+                    "dev-main": "8.1-dev"
                 }
             },
             "autoload": {
@@ -3415,7 +3415,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
                 "security": "https://github.com/sebastianbergmann/environment/security/policy",
-                "source": "https://github.com/sebastianbergmann/environment/tree/8.0.4"
+                "source": "https://github.com/sebastianbergmann/environment/tree/8.1.0"
             },
             "funding": [
                 {
@@ -3435,7 +3435,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-15T07:05:40+00:00"
+            "time": "2026-04-15T12:13:01+00:00"
         },
         {
             "name": "sebastian/exporter",
@@ -4192,7 +4192,7 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.34.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
@@ -4251,7 +4251,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.34.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -4275,7 +4275,7 @@
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.34.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
@@ -4333,7 +4333,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.34.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -4357,7 +4357,7 @@
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.34.0",
+            "version": "v1.36.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
@@ -4418,7 +4418,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.34.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.36.0"
             },
             "funding": [
                 {
@@ -4867,5 +4867,5 @@
         "ext-mbstring": "*"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wp-loupe",
-	"version": "0.8.4",
+	"version": "0.8.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wp-loupe",
-			"version": "0.8.4",
+			"version": "0.8.5",
 			"license": "GPLv2",
 			"dependencies": {
 				"@soderlind/wp-project-version-sync": "^2.0.2",
@@ -23,6 +23,7 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
 			"integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@jridgewell/gen-mapping": "^0.3.5",
@@ -54,12 +55,12 @@
 			"license": "ISC"
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-			"integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+			"integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.27.1",
+				"@babel/helper-validator-identifier": "^7.28.5",
 				"js-tokens": "^4.0.0",
 				"picocolors": "^1.1.1"
 			},
@@ -68,30 +69,30 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz",
-			"integrity": "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+			"integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.7.tgz",
-			"integrity": "sha512-yJ474Zv3cwiSOO9nXJuqzvwEeM+chDuQ8GJirw+pZ91sCGCyOZ3dJkVE09fTV0VEVzXyLWhh3G/AolYTPX7Mow==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+			"integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
 			"license": "MIT",
 			"dependencies": {
-				"@ampproject/remapping": "^2.2.0",
-				"@babel/code-frame": "^7.25.7",
-				"@babel/generator": "^7.25.7",
-				"@babel/helper-compilation-targets": "^7.25.7",
-				"@babel/helper-module-transforms": "^7.25.7",
-				"@babel/helpers": "^7.25.7",
-				"@babel/parser": "^7.25.7",
-				"@babel/template": "^7.25.7",
-				"@babel/traverse": "^7.25.7",
-				"@babel/types": "^7.25.7",
+				"@babel/code-frame": "^7.29.0",
+				"@babel/generator": "^7.29.0",
+				"@babel/helper-compilation-targets": "^7.28.6",
+				"@babel/helper-module-transforms": "^7.28.6",
+				"@babel/helpers": "^7.28.6",
+				"@babel/parser": "^7.29.0",
+				"@babel/template": "^7.28.6",
+				"@babel/traverse": "^7.29.0",
+				"@babel/types": "^7.29.0",
+				"@jridgewell/remapping": "^2.3.5",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -126,13 +127,13 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
-			"integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
+			"version": "7.29.1",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+			"integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.28.5",
-				"@babel/types": "^7.28.5",
+				"@babel/parser": "^7.29.0",
+				"@babel/types": "^7.29.0",
 				"@jridgewell/gen-mapping": "^0.3.12",
 				"@jridgewell/trace-mapping": "^0.3.28",
 				"jsesc": "^3.0.2"
@@ -154,12 +155,12 @@
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.27.2",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-			"integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+			"integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/compat-data": "^7.27.2",
+				"@babel/compat-data": "^7.28.6",
 				"@babel/helper-validator-option": "^7.27.1",
 				"browserslist": "^4.24.0",
 				"lru-cache": "^5.1.1",
@@ -170,17 +171,17 @@
 			}
 		},
 		"node_modules/@babel/helper-create-class-features-plugin": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.5.tgz",
-			"integrity": "sha512-q3WC4JfdODypvxArsJQROfupPBq9+lMwjKq7C33GhbFYJsufD0yd/ziwD+hJucLeWsnFPWZjsU2DNFqBPE7jwQ==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.28.6.tgz",
+			"integrity": "sha512-dTOdvsjnG3xNT9Y0AUg1wAl38y+4Rl4sf9caSQZOXdNqVn+H+HbbJ4IyyHaIqNR6SW9oJpA/RuRjsjCw2IdIow==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.27.3",
 				"@babel/helper-member-expression-to-functions": "^7.28.5",
 				"@babel/helper-optimise-call-expression": "^7.27.1",
-				"@babel/helper-replace-supers": "^7.27.1",
+				"@babel/helper-replace-supers": "^7.28.6",
 				"@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-				"@babel/traverse": "^7.28.5",
+				"@babel/traverse": "^7.28.6",
 				"semver": "^6.3.1"
 			},
 			"engines": {
@@ -208,16 +209,16 @@
 			}
 		},
 		"node_modules/@babel/helper-define-polyfill-provider": {
-			"version": "0.6.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.5.tgz",
-			"integrity": "sha512-uJnGFcPsWQK8fvjgGP5LZUZZsYGIoPeRjSF5PGwrelYgq7Q15/Ft9NGFp1zglwgIv//W0uG4BevRuSJRyylZPg==",
+			"version": "0.6.8",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.6.8.tgz",
+			"integrity": "sha512-47UwBLPpQi1NoWzLuHNjRoHlYXMwIJoBf7MFou6viC/sIHWYygpvr0B6IAyh5sBdA2nr2LPIRww8lfaUVQINBA==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-compilation-targets": "^7.27.2",
-				"@babel/helper-plugin-utils": "^7.27.1",
-				"debug": "^4.4.1",
+				"@babel/helper-compilation-targets": "^7.28.6",
+				"@babel/helper-plugin-utils": "^7.28.6",
+				"debug": "^4.4.3",
 				"lodash.debounce": "^4.0.8",
-				"resolve": "^1.22.10"
+				"resolve": "^1.22.11"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -246,27 +247,27 @@
 			}
 		},
 		"node_modules/@babel/helper-module-imports": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-			"integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+			"integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/traverse": "^7.27.1",
-				"@babel/types": "^7.27.1"
+				"@babel/traverse": "^7.28.6",
+				"@babel/types": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.28.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
-			"integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+			"integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-module-imports": "^7.27.1",
-				"@babel/helper-validator-identifier": "^7.27.1",
-				"@babel/traverse": "^7.28.3"
+				"@babel/helper-module-imports": "^7.28.6",
+				"@babel/helper-validator-identifier": "^7.28.5",
+				"@babel/traverse": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -288,9 +289,9 @@
 			}
 		},
 		"node_modules/@babel/helper-plugin-utils": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
-			"integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+			"integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.9.0"
@@ -314,14 +315,14 @@
 			}
 		},
 		"node_modules/@babel/helper-replace-supers": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.27.1.tgz",
-			"integrity": "sha512-7EHz6qDZc8RYS5ElPoShMheWvEgERonFCs7IAonWLLUTXW59DP14bCZt89/GKyreYn8g3S83m21FelHKbeDCKA==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.28.6.tgz",
+			"integrity": "sha512-mq8e+laIk94/yFec3DxSjCRD2Z0TAjhVbEJY3UQrlwVo15Lmt7C2wAUbK4bjnTs4APkwsYLTahXRraQXhb1WCg==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-member-expression-to-functions": "^7.27.1",
+				"@babel/helper-member-expression-to-functions": "^7.28.5",
 				"@babel/helper-optimise-call-expression": "^7.27.1",
-				"@babel/traverse": "^7.27.1"
+				"@babel/traverse": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -371,39 +372,39 @@
 			}
 		},
 		"node_modules/@babel/helper-wrap-function": {
-			"version": "7.28.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.28.3.tgz",
-			"integrity": "sha512-zdf983tNfLZFletc0RRXYrHrucBEg95NIFMkn6K9dbeMYnsgHaSBGcQqdsCSStG2PYwRre0Qc2NNSCXbG+xc6g==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-wrap-function/-/helper-wrap-function-7.28.6.tgz",
+			"integrity": "sha512-z+PwLziMNBeSQJonizz2AGnndLsP2DeGHIxDAn+wdHOGuo4Fo1x1HBPPXeE9TAOPHNNWQKCSlA2VZyYyyibDnQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/template": "^7.27.2",
-				"@babel/traverse": "^7.28.3",
-				"@babel/types": "^7.28.2"
+				"@babel/template": "^7.28.6",
+				"@babel/traverse": "^7.28.6",
+				"@babel/types": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.28.4",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
-			"integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+			"integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/template": "^7.27.2",
-				"@babel/types": "^7.28.4"
+				"@babel/template": "^7.28.6",
+				"@babel/types": "^7.29.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-			"integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+			"integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.28.5"
+				"@babel/types": "^7.29.0"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -476,13 +477,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": {
-			"version": "7.28.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.28.3.tgz",
-			"integrity": "sha512-b6YTX108evsvE4YgWyQ921ZAFFQm3Bn+CA3+ZXlNVnPhx+UfsVURoPjfGAPCjBgrqo30yX/C2nZGX96DxvR9Iw==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly/-/plugin-bugfix-v8-static-class-fields-redefine-readonly-7.28.6.tgz",
+			"integrity": "sha512-a0aBScVTlNaiUe35UtfxAN7A/tehvvG4/ByO6+46VPKTRSlfnAFsgKy0FUh+qAkQrDTmhDkT+IBOKlOoMUxQ0g==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1",
-				"@babel/traverse": "^7.28.3"
+				"@babel/helper-plugin-utils": "^7.28.6",
+				"@babel/traverse": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -558,6 +559,7 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
 			"integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.8.0"
@@ -570,6 +572,7 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz",
 			"integrity": "sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-plugin-utils": "^7.8.3"
@@ -579,12 +582,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-import-assertions": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.27.1.tgz",
-			"integrity": "sha512-UT/Jrhw57xg4ILHLFnzFpPDlMbcdEicaAtjPQpbj9wa8T4r5KVWCimHcL/460g8Ht0DMxDyjsLgiWSkVjnwPFg==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-assertions/-/plugin-syntax-import-assertions-7.28.6.tgz",
+			"integrity": "sha512-pSJUpFHdx9z5nqTSirOCMtYVP2wFgoWhP0p3g8ONK/4IHhLIBd0B9NYqAvIUAhq+OkhO4VM1tENCt0cjlsNShw==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -594,12 +597,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-import-attributes": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.27.1.tgz",
-			"integrity": "sha512-oFT0FrKHgF53f4vOsZGi2Hh3I35PfSmVs4IBFLFj4dnafP+hIWDLg3VyKmUHfLoLHlyxY4C7DGtmHuJgn+IGww==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
+			"integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -633,13 +636,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-jsx": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.27.1.tgz",
-			"integrity": "sha512-y8YTNIeKoyhGd9O0Jiyzyyqk8gdjnumGTQPsz0xOZOQ2RmkVJeZ1vmmfIvFEKqucBG6axJGBZDE/7iI5suUI/w==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
+			"integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -751,13 +754,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-syntax-typescript": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.27.1.tgz",
-			"integrity": "sha512-xfYCBMxveHrRMnAWl1ZlPXOZjzkN82THFvLhQhFXFt81Z5HnN+EtUkZhv/zcKpmT3fzmWZB0ywiBrbC3vogbwQ==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.28.6.tgz",
+			"integrity": "sha512-+nDNmQye7nlnuuHDboPbGm00Vqg3oO8niRRL27/4LYHUsHYh0zJ1xWOz0uRwNFmM1Avzk8wZbc6rdiYhomzv/A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -798,14 +801,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-async-generator-functions": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.28.0.tgz",
-			"integrity": "sha512-BEOdvX4+M765icNPZeidyADIvQ1m1gmunXufXxvRESy/jNNyfovIqUyE7MVgGBjWktCoJlzvFA1To2O4ymIO3Q==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.29.0.tgz",
+			"integrity": "sha512-va0VdWro4zlBr2JsXC+ofCPB2iG12wPtVGTWFx2WLDOM3nYQZZIGP82qku2eW/JR83sD+k2k+CsNtyEbUqhU6w==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1",
+				"@babel/helper-plugin-utils": "^7.28.6",
 				"@babel/helper-remap-async-to-generator": "^7.27.1",
-				"@babel/traverse": "^7.28.0"
+				"@babel/traverse": "^7.29.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -815,13 +818,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-async-to-generator": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.27.1.tgz",
-			"integrity": "sha512-NREkZsZVJS4xmTr8qzE5y8AfIPqsdQfRuUiLRTEzb7Qii8iFWCyDKaUV2c0rCuh4ljDZ98ALHP/PetiBV2nddA==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-to-generator/-/plugin-transform-async-to-generator-7.28.6.tgz",
+			"integrity": "sha512-ilTRcmbuXjsMmcZ3HASTe4caH5Tpo93PkTxF9oG2VZsSWsahydmcEHhix9Ik122RcTnZnUzPbmux4wh1swfv7g==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-module-imports": "^7.27.1",
-				"@babel/helper-plugin-utils": "^7.27.1",
+				"@babel/helper-module-imports": "^7.28.6",
+				"@babel/helper-plugin-utils": "^7.28.6",
 				"@babel/helper-remap-async-to-generator": "^7.27.1"
 			},
 			"engines": {
@@ -847,12 +850,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-block-scoping": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.5.tgz",
-			"integrity": "sha512-45DmULpySVvmq9Pj3X9B+62Xe+DJGov27QravQJU1LLcapR6/10i+gYVAucGGJpHBp5mYxIMK4nDAT/QDLr47g==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-block-scoping/-/plugin-transform-block-scoping-7.28.6.tgz",
+			"integrity": "sha512-tt/7wOtBmwHPNMPu7ax4pdPz6shjFrmHDghvNC+FG9Qvj7D6mJcoRQIF5dy4njmxR941l6rgtvfSB2zX3VlUIw==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -862,13 +865,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-class-properties": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.27.1.tgz",
-			"integrity": "sha512-D0VcalChDMtuRvJIu3U/fwWjf8ZMykz5iZsg77Nuj821vCKI3zCyRLwRdWbsuJ/uRwZhZ002QtCqIkwC/ZkvbA==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-properties/-/plugin-transform-class-properties-7.28.6.tgz",
+			"integrity": "sha512-dY2wS3I2G7D697VHndN91TJr8/AAfXQNt5ynCTI/MpxMsSzHp+52uNivYT5wCPax3whc47DR8Ba7cmlQMg24bw==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-create-class-features-plugin": "^7.27.1",
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-create-class-features-plugin": "^7.28.6",
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -878,13 +881,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-class-static-block": {
-			"version": "7.28.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.28.3.tgz",
-			"integrity": "sha512-LtPXlBbRoc4Njl/oh1CeD/3jC+atytbnf/UqLoqTDcEYGUPj022+rvfkbDYieUrSj3CaV4yHDByPE+T2HwfsJg==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-class-static-block/-/plugin-transform-class-static-block-7.28.6.tgz",
+			"integrity": "sha512-rfQ++ghVwTWTqQ7w8qyDxL1XGihjBss4CmTgGRCTAC9RIbhVpyp4fOeZtta0Lbf+dTNIVJer6ych2ibHwkZqsQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-create-class-features-plugin": "^7.28.3",
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-create-class-features-plugin": "^7.28.6",
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -894,17 +897,17 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-classes": {
-			"version": "7.28.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.4.tgz",
-			"integrity": "sha512-cFOlhIYPBv/iBoc+KS3M6et2XPtbT2HiCRfBXWtfpc9OAyostldxIf9YAYB6ypURBBbx+Qv6nyrLzASfJe+hBA==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-classes/-/plugin-transform-classes-7.28.6.tgz",
+			"integrity": "sha512-EF5KONAqC5zAqT783iMGuM2ZtmEBy+mJMOKl2BCvPZ2lVrwvXnB6o+OBWCS+CoeCCpVRF2sA2RBKUxvT8tQT5Q==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.27.3",
-				"@babel/helper-compilation-targets": "^7.27.2",
+				"@babel/helper-compilation-targets": "^7.28.6",
 				"@babel/helper-globals": "^7.28.0",
-				"@babel/helper-plugin-utils": "^7.27.1",
-				"@babel/helper-replace-supers": "^7.27.1",
-				"@babel/traverse": "^7.28.4"
+				"@babel/helper-plugin-utils": "^7.28.6",
+				"@babel/helper-replace-supers": "^7.28.6",
+				"@babel/traverse": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -914,13 +917,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-computed-properties": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.27.1.tgz",
-			"integrity": "sha512-lj9PGWvMTVksbWiDT2tW68zGS/cyo4AkZ/QTp0sQT0mjPopCmrSkzxeXkznjqBxzDI6TclZhOJbBmbBLjuOZUw==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-computed-properties/-/plugin-transform-computed-properties-7.28.6.tgz",
+			"integrity": "sha512-bcc3k0ijhHbc2lEfpFHgx7eYw9KNXqOerKWfzbxEHUGKnS3sz9C4CNL9OiFN1297bDNfUiSO7DaLzbvHQQQ1BQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1",
-				"@babel/template": "^7.27.1"
+				"@babel/helper-plugin-utils": "^7.28.6",
+				"@babel/template": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -946,13 +949,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-dotall-regex": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.27.1.tgz",
-			"integrity": "sha512-gEbkDVGRvjj7+T1ivxrfgygpT7GUd4vmODtYpbs0gZATdkX8/iSnOtZSxiZnsgm1YjTgjI6VKBGSJJevkrclzw==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dotall-regex/-/plugin-transform-dotall-regex-7.28.6.tgz",
+			"integrity": "sha512-SljjowuNKB7q5Oayv4FoPzeB74g3QgLt8IVJw9ADvWy3QnUb/01aw8I4AVv8wYnPvQz2GDDZ/g3GhcNyDBI4Bg==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.27.1",
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-create-regexp-features-plugin": "^7.28.5",
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -977,13 +980,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-duplicate-named-capturing-groups-regex": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.27.1.tgz",
-			"integrity": "sha512-hkGcueTEzuhB30B3eJCbCYeCaaEQOmQR0AdvzpD4LoN0GXMWzzGSuRrxR2xTnCrvNbVwK9N6/jQ92GSLfiZWoQ==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-duplicate-named-capturing-groups-regex/-/plugin-transform-duplicate-named-capturing-groups-regex-7.29.0.tgz",
+			"integrity": "sha512-zBPcW2lFGxdiD8PUnPwJjag2J9otbcLQzvbiOzDxpYXyCuYX9agOwMPGn1prVH0a4qzhCKu24rlH4c1f7yA8rw==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.27.1",
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-create-regexp-features-plugin": "^7.28.5",
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1007,13 +1010,29 @@
 				"@babel/core": "^7.0.0-0"
 			}
 		},
-		"node_modules/@babel/plugin-transform-exponentiation-operator": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.28.5.tgz",
-			"integrity": "sha512-D4WIMaFtwa2NizOp+dnoFjRez/ClKiC2BqqImwKd1X28nqBtZEyCYJ2ozQrrzlxAFrcrjxo39S6khe9RNDlGzw==",
+		"node_modules/@babel/plugin-transform-explicit-resource-management": {
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-explicit-resource-management/-/plugin-transform-explicit-resource-management-7.28.6.tgz",
+			"integrity": "sha512-Iao5Konzx2b6g7EPqTy40UZbcdXE126tTxVFr/nAIj+WItNxjKSYTEw3RC+A2/ZetmdJsgueL1KhaMCQHkLPIg==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-plugin-utils": "^7.28.6",
+				"@babel/plugin-transform-destructuring": "^7.28.5"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-transform-exponentiation-operator": {
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-exponentiation-operator/-/plugin-transform-exponentiation-operator-7.28.6.tgz",
+			"integrity": "sha512-WitabqiGjV/vJ0aPOLSFfNY1u9U3R7W36B03r5I2KoNix+a3sOhJ3pKFB3R5It9/UiK78NiO0KE9P21cMhlPkw==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1071,12 +1090,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-json-strings": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.27.1.tgz",
-			"integrity": "sha512-6WVLVJiTjqcQauBhn1LkICsR2H+zm62I3h9faTDKt1qP4jn2o72tSvqMwtGFKGTpojce0gJs+76eZ2uCHRZh0Q==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-json-strings/-/plugin-transform-json-strings-7.28.6.tgz",
+			"integrity": "sha512-Nr+hEN+0geQkzhbdgQVPoqr47lZbm+5fCUmO70722xJZd0Mvb59+33QLImGj6F+DkK3xgDi1YVysP8whD6FQAw==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1101,12 +1120,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-logical-assignment-operators": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.28.5.tgz",
-			"integrity": "sha512-axUuqnUTBuXyHGcJEVVh9pORaN6wC5bYfE7FGzPiaWa3syib9m7g+/IT/4VgCOe2Upef43PHzeAvcrVek6QuuA==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-logical-assignment-operators/-/plugin-transform-logical-assignment-operators-7.28.6.tgz",
+			"integrity": "sha512-+anKKair6gpi8VsM/95kmomGNMD0eLz1NQ8+Pfw5sAwWH9fGYXT50E55ZpV0pHUHWf6IUTWPM+f/7AAff+wr9A==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1147,13 +1166,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-commonjs": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.27.1.tgz",
-			"integrity": "sha512-OJguuwlTYlN0gBZFRPqwOGNWssZjfIUdS7HMYtN8c1KmwpwHFBwTeFZrg9XZa+DFTitWOW5iTAG7tyCUPsCCyw==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.28.6.tgz",
+			"integrity": "sha512-jppVbf8IV9iWWwWTQIxJMAJCWBuuKx71475wHwYytrRGQ2CWiDvYlADQno3tcYpS/T2UUWFQp3nVtYfK/YBQrA==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-module-transforms": "^7.27.1",
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-module-transforms": "^7.28.6",
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1163,15 +1182,15 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-systemjs": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.28.5.tgz",
-			"integrity": "sha512-vn5Jma98LCOeBy/KpeQhXcV2WZgaRUtjwQmjoBuLNlOmkg0fB5pdvYVeWRYI69wWKwK2cD1QbMiUQnoujWvrew==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
+			"integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-module-transforms": "^7.28.3",
-				"@babel/helper-plugin-utils": "^7.27.1",
+				"@babel/helper-module-transforms": "^7.28.6",
+				"@babel/helper-plugin-utils": "^7.28.6",
 				"@babel/helper-validator-identifier": "^7.28.5",
-				"@babel/traverse": "^7.28.5"
+				"@babel/traverse": "^7.29.0"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1197,13 +1216,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-named-capturing-groups-regex": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.27.1.tgz",
-			"integrity": "sha512-SstR5JYy8ddZvD6MhV0tM/j16Qds4mIpJTOd1Yu9J9pJjH93bxHECF7pgtc28XvkzTD6Pxcm/0Z73Hvk7kb3Ng==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-named-capturing-groups-regex/-/plugin-transform-named-capturing-groups-regex-7.29.0.tgz",
+			"integrity": "sha512-1CZQA5KNAD6ZYQLPw7oi5ewtDNxH/2vuCh+6SmvgDfhumForvs8a1o9n0UrEoBD8HU4djO2yWngTQlXl1NDVEQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.27.1",
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-create-regexp-features-plugin": "^7.28.5",
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1228,12 +1247,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.27.1.tgz",
-			"integrity": "sha512-aGZh6xMo6q9vq1JGcw58lZ1Z0+i0xB2x0XaauNIUXd6O1xXc3RwoWEBlsTQrY4KQ9Jf0s5rgD6SiNkaUdJegTA==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-nullish-coalescing-operator/-/plugin-transform-nullish-coalescing-operator-7.28.6.tgz",
+			"integrity": "sha512-3wKbRgmzYbw24mDJXT7N+ADXw8BC/imU9yo9c9X9NKaLF1fW+e5H1U5QjMUBe4Qo4Ox/o++IyUkl1sVCLgevKg==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1243,12 +1262,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-numeric-separator": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.27.1.tgz",
-			"integrity": "sha512-fdPKAcujuvEChxDBJ5c+0BTaS6revLV7CJL08e4m3de8qJfNIuCc2nc7XJYOjBoTMJeqSmwXJ0ypE14RCjLwaw==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-numeric-separator/-/plugin-transform-numeric-separator-7.28.6.tgz",
+			"integrity": "sha512-SJR8hPynj8outz+SlStQSwvziMN4+Bq99it4tMIf5/Caq+3iOc0JtKyse8puvyXkk3eFRIA5ID/XfunGgO5i6w==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1258,16 +1277,16 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-object-rest-spread": {
-			"version": "7.28.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.28.4.tgz",
-			"integrity": "sha512-373KA2HQzKhQCYiRVIRr+3MjpCObqzDlyrM6u4I201wL8Mp2wHf7uB8GhDwis03k2ti8Zr65Zyyqs1xOxUF/Ew==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-object-rest-spread/-/plugin-transform-object-rest-spread-7.28.6.tgz",
+			"integrity": "sha512-5rh+JR4JBC4pGkXLAcYdLHZjXudVxWMXbB6u6+E9lRL5TrGVbHt1TjxGbZ8CkmYw9zjkB7jutzOROArsqtncEA==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-compilation-targets": "^7.27.2",
-				"@babel/helper-plugin-utils": "^7.27.1",
-				"@babel/plugin-transform-destructuring": "^7.28.0",
+				"@babel/helper-compilation-targets": "^7.28.6",
+				"@babel/helper-plugin-utils": "^7.28.6",
+				"@babel/plugin-transform-destructuring": "^7.28.5",
 				"@babel/plugin-transform-parameters": "^7.27.7",
-				"@babel/traverse": "^7.28.4"
+				"@babel/traverse": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1293,12 +1312,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-optional-catch-binding": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.27.1.tgz",
-			"integrity": "sha512-txEAEKzYrHEX4xSZN4kJ+OfKXFVSWKB2ZxM9dpcE3wT7smwkNmXo5ORRlVzMVdJbD+Q8ILTgSD7959uj+3Dm3Q==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-catch-binding/-/plugin-transform-optional-catch-binding-7.28.6.tgz",
+			"integrity": "sha512-R8ja/Pyrv0OGAvAXQhSTmWyPJPml+0TMqXlO5w+AsMEiwb2fg3WkOvob7UxFSL3OIttFSGSRFKQsOhJ/X6HQdQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1308,12 +1327,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-optional-chaining": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.28.5.tgz",
-			"integrity": "sha512-N6fut9IZlPnjPwgiQkXNhb+cT8wQKFlJNqcZkWlcTqkcqx6/kU4ynGmLFoa4LViBSirn05YAwk+sQBbPfxtYzQ==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-optional-chaining/-/plugin-transform-optional-chaining-7.28.6.tgz",
+			"integrity": "sha512-A4zobikRGJTsX9uqVFdafzGkqD30t26ck2LmOzAuLL8b2x6k3TIqRiT2xVvA9fNmFeTX484VpsdgmKNA0bS23w==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1",
+				"@babel/helper-plugin-utils": "^7.28.6",
 				"@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
 			},
 			"engines": {
@@ -1339,13 +1358,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-private-methods": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.27.1.tgz",
-			"integrity": "sha512-10FVt+X55AjRAYI9BrdISN9/AQWHqldOeZDUoLyif1Kn05a56xVBXb8ZouL8pZ9jem8QpXaOt8TS7RHUIS+GPA==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-methods/-/plugin-transform-private-methods-7.28.6.tgz",
+			"integrity": "sha512-piiuapX9CRv7+0st8lmuUlRSmX6mBcVeNQ1b4AYzJxfCMuBfB0vBXDiGSmm03pKJw1v6cZ8KSeM+oUnM6yAExg==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-create-class-features-plugin": "^7.27.1",
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-create-class-features-plugin": "^7.28.6",
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1355,14 +1374,14 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-private-property-in-object": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.27.1.tgz",
-			"integrity": "sha512-5J+IhqTi1XPa0DXF83jYOaARrX+41gOewWbkPyjMNRDqgOCqdffGh8L3f/Ek5utaEBZExjSAzcyjmV9SSAWObQ==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-private-property-in-object/-/plugin-transform-private-property-in-object-7.28.6.tgz",
+			"integrity": "sha512-b97jvNSOb5+ehyQmBpmhOCiUC5oVK4PMnpRvO7+ymFBoqYjeDHIU9jnrNUuwHOiL9RpGDoKBpSViarV+BU+eVA==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.27.1",
-				"@babel/helper-create-class-features-plugin": "^7.27.1",
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-annotate-as-pure": "^7.27.3",
+				"@babel/helper-create-class-features-plugin": "^7.28.6",
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1419,17 +1438,17 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-react-jsx": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.27.1.tgz",
-			"integrity": "sha512-2KH4LWGSrJIkVf5tSiBFYuXDAoWRq2MMwgivCf+93dd0GQi8RXLjKA/0EvRnVV5G0hrHczsquXuD01L8s6dmBw==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.28.6.tgz",
+			"integrity": "sha512-61bxqhiRfAACulXSLd/GxqmAedUSrRZIu/cbaT18T1CetkTmtDN15it7i80ru4DVqRK1WMxQhXs+Lf9kajm5Ow==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.27.1",
-				"@babel/helper-module-imports": "^7.27.1",
-				"@babel/helper-plugin-utils": "^7.27.1",
-				"@babel/plugin-syntax-jsx": "^7.27.1",
-				"@babel/types": "^7.27.1"
+				"@babel/helper-annotate-as-pure": "^7.27.3",
+				"@babel/helper-module-imports": "^7.28.6",
+				"@babel/helper-plugin-utils": "^7.28.6",
+				"@babel/plugin-syntax-jsx": "^7.28.6",
+				"@babel/types": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1472,18 +1491,34 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-regenerator": {
-			"version": "7.28.4",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.28.4.tgz",
-			"integrity": "sha512-+ZEdQlBoRg9m2NnzvEeLgtvBMO4tkFBw5SQIUgLICgTrumLoU7lr+Oghi6km2PFj+dbUt2u1oby2w3BDO9YQnA==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.0.tgz",
+			"integrity": "sha512-FijqlqMA7DmRdg/aINBSs04y8XNTYw/lr1gJ2WsmBnnaNw1iS43EPkJW+zK7z65auG3AWRFXWj+NcTQwYptUog==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@babel/plugin-transform-regexp-modifiers": {
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-regexp-modifiers/-/plugin-transform-regexp-modifiers-7.28.6.tgz",
+			"integrity": "sha512-QGWAepm9qxpaIs7UM9FvUSnCGlb8Ua1RhyM4/veAxLwt3gMat/LSGrZixyuj4I6+Kn9iwvqCyPTtbdxanYoWYg==",
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-create-regexp-features-plugin": "^7.28.5",
+				"@babel/helper-plugin-utils": "^7.28.6"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0"
 			}
 		},
 		"node_modules/@babel/plugin-transform-reserved-words": {
@@ -1522,6 +1557,20 @@
 				"@babel/core": "^7.0.0-0"
 			}
 		},
+		"node_modules/@babel/plugin-transform-runtime/node_modules/babel-plugin-polyfill-corejs3": {
+			"version": "0.10.6",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.10.6.tgz",
+			"integrity": "sha512-b37+KR2i/khY5sKmWNVQAnitvquQbNdWy6lJdsr0kmquCKEEUgMKK4SboVM3HtfnZilfjr4MMQ7vY58FVWDtIA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-define-polyfill-provider": "^0.6.2",
+				"core-js-compat": "^3.38.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+			}
+		},
 		"node_modules/@babel/plugin-transform-shorthand-properties": {
 			"version": "7.27.1",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.27.1.tgz",
@@ -1538,12 +1587,12 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-spread": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.27.1.tgz",
-			"integrity": "sha512-kpb3HUqaILBJcRFVhFUs6Trdd4mkrzcGXss+6/mxUd273PfbWqSDHRzMT2234gIg2QYfAjvXLSquP1xECSg09Q==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.28.6.tgz",
+			"integrity": "sha512-9U4QObUC0FtJl05AsUcodau/RWDytrU6uKgkxu09mLR9HLDAtUMoPuuskm5huQsoktmsYpI+bGmq+iapDcriKA==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.27.1",
+				"@babel/helper-plugin-utils": "^7.28.6",
 				"@babel/helper-skip-transparent-expression-wrappers": "^7.27.1"
 			},
 			"engines": {
@@ -1599,17 +1648,17 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-typescript": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.5.tgz",
-			"integrity": "sha512-x2Qa+v/CuEoX7Dr31iAfr0IhInrVOWZU/2vJMJ00FOR/2nM0BcBEclpaf9sWCDc+v5e9dMrhSH8/atq/kX7+bA==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.28.6.tgz",
+			"integrity": "sha512-0YWL2RFxOqEm9Efk5PvreamxPME8OyY0wM5wh5lHjF+VtVhdneCWGzZeSqzOfiobVqQaNCd2z0tQvnI9DaPWPw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.27.3",
-				"@babel/helper-create-class-features-plugin": "^7.28.5",
-				"@babel/helper-plugin-utils": "^7.27.1",
+				"@babel/helper-create-class-features-plugin": "^7.28.6",
+				"@babel/helper-plugin-utils": "^7.28.6",
 				"@babel/helper-skip-transparent-expression-wrappers": "^7.27.1",
-				"@babel/plugin-syntax-typescript": "^7.27.1"
+				"@babel/plugin-syntax-typescript": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1634,13 +1683,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-unicode-property-regex": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.27.1.tgz",
-			"integrity": "sha512-uW20S39PnaTImxp39O5qFlHLS9LJEmANjMG7SxIhap8rCHqu0Ik+tLEPX5DKmHn6CsWQ7j3lix2tFOa5YtL12Q==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-property-regex/-/plugin-transform-unicode-property-regex-7.28.6.tgz",
+			"integrity": "sha512-4Wlbdl/sIZjzi/8St0evF0gEZrgOswVO6aOzqxh1kDZOl9WmLrHq2HtGhnOJZmHZYKP8WZ1MDLCt5DAWwRo57A==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.27.1",
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-create-regexp-features-plugin": "^7.28.5",
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1666,13 +1715,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-unicode-sets-regex": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.27.1.tgz",
-			"integrity": "sha512-EtkOujbc4cgvb0mlpQefi4NTPBzhSIevblFevACNLUspmrALgmEBdL/XfnyyITfd8fKBZrZys92zOWcik7j9Tw==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-sets-regex/-/plugin-transform-unicode-sets-regex-7.28.6.tgz",
+			"integrity": "sha512-/wHc/paTUmsDYN7SZkpWxogTOBNnlx7nBQYfy6JJlCT7G3mVhltk3e++N7zV0XfgGsrqBxd4rJQt9H16I21Y1Q==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-create-regexp-features-plugin": "^7.27.1",
-				"@babel/helper-plugin-utils": "^7.27.1"
+				"@babel/helper-create-regexp-features-plugin": "^7.28.5",
+				"@babel/helper-plugin-utils": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1682,93 +1731,80 @@
 			}
 		},
 		"node_modules/@babel/preset-env": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.25.7.tgz",
-			"integrity": "sha512-Gibz4OUdyNqqLj+7OAvBZxOD7CklCtMA5/j0JgUEwOnaRULsPDXmic2iKxL2DX2vQduPR5wH2hjZas/Vr/Oc0g==",
+			"version": "7.29.2",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.29.2.tgz",
+			"integrity": "sha512-DYD23veRYGvBFhcTY1iUvJnDNpuqNd/BzBwCvzOTKUnJjKg5kpUBh3/u9585Agdkgj+QuygG7jLfOPWMa2KVNw==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/compat-data": "^7.25.7",
-				"@babel/helper-compilation-targets": "^7.25.7",
-				"@babel/helper-plugin-utils": "^7.25.7",
-				"@babel/helper-validator-option": "^7.25.7",
-				"@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.25.7",
-				"@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.25.7",
-				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.25.7",
-				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.25.7",
-				"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.25.7",
+				"@babel/compat-data": "^7.29.0",
+				"@babel/helper-compilation-targets": "^7.28.6",
+				"@babel/helper-plugin-utils": "^7.28.6",
+				"@babel/helper-validator-option": "^7.27.1",
+				"@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.28.5",
+				"@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.27.1",
+				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.27.1",
+				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.27.1",
+				"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.28.6",
 				"@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
-				"@babel/plugin-syntax-async-generators": "^7.8.4",
-				"@babel/plugin-syntax-class-properties": "^7.12.13",
-				"@babel/plugin-syntax-class-static-block": "^7.14.5",
-				"@babel/plugin-syntax-dynamic-import": "^7.8.3",
-				"@babel/plugin-syntax-export-namespace-from": "^7.8.3",
-				"@babel/plugin-syntax-import-assertions": "^7.25.7",
-				"@babel/plugin-syntax-import-attributes": "^7.25.7",
-				"@babel/plugin-syntax-import-meta": "^7.10.4",
-				"@babel/plugin-syntax-json-strings": "^7.8.3",
-				"@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
-				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-				"@babel/plugin-syntax-numeric-separator": "^7.10.4",
-				"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-				"@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
-				"@babel/plugin-syntax-optional-chaining": "^7.8.3",
-				"@babel/plugin-syntax-private-property-in-object": "^7.14.5",
-				"@babel/plugin-syntax-top-level-await": "^7.14.5",
+				"@babel/plugin-syntax-import-assertions": "^7.28.6",
+				"@babel/plugin-syntax-import-attributes": "^7.28.6",
 				"@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
-				"@babel/plugin-transform-arrow-functions": "^7.25.7",
-				"@babel/plugin-transform-async-generator-functions": "^7.25.7",
-				"@babel/plugin-transform-async-to-generator": "^7.25.7",
-				"@babel/plugin-transform-block-scoped-functions": "^7.25.7",
-				"@babel/plugin-transform-block-scoping": "^7.25.7",
-				"@babel/plugin-transform-class-properties": "^7.25.7",
-				"@babel/plugin-transform-class-static-block": "^7.25.7",
-				"@babel/plugin-transform-classes": "^7.25.7",
-				"@babel/plugin-transform-computed-properties": "^7.25.7",
-				"@babel/plugin-transform-destructuring": "^7.25.7",
-				"@babel/plugin-transform-dotall-regex": "^7.25.7",
-				"@babel/plugin-transform-duplicate-keys": "^7.25.7",
-				"@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.25.7",
-				"@babel/plugin-transform-dynamic-import": "^7.25.7",
-				"@babel/plugin-transform-exponentiation-operator": "^7.25.7",
-				"@babel/plugin-transform-export-namespace-from": "^7.25.7",
-				"@babel/plugin-transform-for-of": "^7.25.7",
-				"@babel/plugin-transform-function-name": "^7.25.7",
-				"@babel/plugin-transform-json-strings": "^7.25.7",
-				"@babel/plugin-transform-literals": "^7.25.7",
-				"@babel/plugin-transform-logical-assignment-operators": "^7.25.7",
-				"@babel/plugin-transform-member-expression-literals": "^7.25.7",
-				"@babel/plugin-transform-modules-amd": "^7.25.7",
-				"@babel/plugin-transform-modules-commonjs": "^7.25.7",
-				"@babel/plugin-transform-modules-systemjs": "^7.25.7",
-				"@babel/plugin-transform-modules-umd": "^7.25.7",
-				"@babel/plugin-transform-named-capturing-groups-regex": "^7.25.7",
-				"@babel/plugin-transform-new-target": "^7.25.7",
-				"@babel/plugin-transform-nullish-coalescing-operator": "^7.25.7",
-				"@babel/plugin-transform-numeric-separator": "^7.25.7",
-				"@babel/plugin-transform-object-rest-spread": "^7.25.7",
-				"@babel/plugin-transform-object-super": "^7.25.7",
-				"@babel/plugin-transform-optional-catch-binding": "^7.25.7",
-				"@babel/plugin-transform-optional-chaining": "^7.25.7",
-				"@babel/plugin-transform-parameters": "^7.25.7",
-				"@babel/plugin-transform-private-methods": "^7.25.7",
-				"@babel/plugin-transform-private-property-in-object": "^7.25.7",
-				"@babel/plugin-transform-property-literals": "^7.25.7",
-				"@babel/plugin-transform-regenerator": "^7.25.7",
-				"@babel/plugin-transform-reserved-words": "^7.25.7",
-				"@babel/plugin-transform-shorthand-properties": "^7.25.7",
-				"@babel/plugin-transform-spread": "^7.25.7",
-				"@babel/plugin-transform-sticky-regex": "^7.25.7",
-				"@babel/plugin-transform-template-literals": "^7.25.7",
-				"@babel/plugin-transform-typeof-symbol": "^7.25.7",
-				"@babel/plugin-transform-unicode-escapes": "^7.25.7",
-				"@babel/plugin-transform-unicode-property-regex": "^7.25.7",
-				"@babel/plugin-transform-unicode-regex": "^7.25.7",
-				"@babel/plugin-transform-unicode-sets-regex": "^7.25.7",
+				"@babel/plugin-transform-arrow-functions": "^7.27.1",
+				"@babel/plugin-transform-async-generator-functions": "^7.29.0",
+				"@babel/plugin-transform-async-to-generator": "^7.28.6",
+				"@babel/plugin-transform-block-scoped-functions": "^7.27.1",
+				"@babel/plugin-transform-block-scoping": "^7.28.6",
+				"@babel/plugin-transform-class-properties": "^7.28.6",
+				"@babel/plugin-transform-class-static-block": "^7.28.6",
+				"@babel/plugin-transform-classes": "^7.28.6",
+				"@babel/plugin-transform-computed-properties": "^7.28.6",
+				"@babel/plugin-transform-destructuring": "^7.28.5",
+				"@babel/plugin-transform-dotall-regex": "^7.28.6",
+				"@babel/plugin-transform-duplicate-keys": "^7.27.1",
+				"@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.29.0",
+				"@babel/plugin-transform-dynamic-import": "^7.27.1",
+				"@babel/plugin-transform-explicit-resource-management": "^7.28.6",
+				"@babel/plugin-transform-exponentiation-operator": "^7.28.6",
+				"@babel/plugin-transform-export-namespace-from": "^7.27.1",
+				"@babel/plugin-transform-for-of": "^7.27.1",
+				"@babel/plugin-transform-function-name": "^7.27.1",
+				"@babel/plugin-transform-json-strings": "^7.28.6",
+				"@babel/plugin-transform-literals": "^7.27.1",
+				"@babel/plugin-transform-logical-assignment-operators": "^7.28.6",
+				"@babel/plugin-transform-member-expression-literals": "^7.27.1",
+				"@babel/plugin-transform-modules-amd": "^7.27.1",
+				"@babel/plugin-transform-modules-commonjs": "^7.28.6",
+				"@babel/plugin-transform-modules-systemjs": "^7.29.0",
+				"@babel/plugin-transform-modules-umd": "^7.27.1",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^7.29.0",
+				"@babel/plugin-transform-new-target": "^7.27.1",
+				"@babel/plugin-transform-nullish-coalescing-operator": "^7.28.6",
+				"@babel/plugin-transform-numeric-separator": "^7.28.6",
+				"@babel/plugin-transform-object-rest-spread": "^7.28.6",
+				"@babel/plugin-transform-object-super": "^7.27.1",
+				"@babel/plugin-transform-optional-catch-binding": "^7.28.6",
+				"@babel/plugin-transform-optional-chaining": "^7.28.6",
+				"@babel/plugin-transform-parameters": "^7.27.7",
+				"@babel/plugin-transform-private-methods": "^7.28.6",
+				"@babel/plugin-transform-private-property-in-object": "^7.28.6",
+				"@babel/plugin-transform-property-literals": "^7.27.1",
+				"@babel/plugin-transform-regenerator": "^7.29.0",
+				"@babel/plugin-transform-regexp-modifiers": "^7.28.6",
+				"@babel/plugin-transform-reserved-words": "^7.27.1",
+				"@babel/plugin-transform-shorthand-properties": "^7.27.1",
+				"@babel/plugin-transform-spread": "^7.28.6",
+				"@babel/plugin-transform-sticky-regex": "^7.27.1",
+				"@babel/plugin-transform-template-literals": "^7.27.1",
+				"@babel/plugin-transform-typeof-symbol": "^7.27.1",
+				"@babel/plugin-transform-unicode-escapes": "^7.27.1",
+				"@babel/plugin-transform-unicode-property-regex": "^7.28.6",
+				"@babel/plugin-transform-unicode-regex": "^7.27.1",
+				"@babel/plugin-transform-unicode-sets-regex": "^7.28.6",
 				"@babel/preset-modules": "0.1.6-no-external-plugins",
-				"babel-plugin-polyfill-corejs2": "^0.4.10",
-				"babel-plugin-polyfill-corejs3": "^0.10.6",
-				"babel-plugin-polyfill-regenerator": "^0.6.1",
-				"core-js-compat": "^3.38.1",
+				"babel-plugin-polyfill-corejs2": "^0.4.15",
+				"babel-plugin-polyfill-corejs3": "^0.14.0",
+				"babel-plugin-polyfill-regenerator": "^0.6.6",
+				"core-js-compat": "^3.48.0",
 				"semver": "^6.3.1"
 			},
 			"engines": {
@@ -1814,17 +1850,17 @@
 			}
 		},
 		"node_modules/@babel/preset-typescript": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.25.7.tgz",
-			"integrity": "sha512-rkkpaXJZOFN45Fb+Gki0c+KMIglk4+zZXOoMJuyEK8y8Kkc8Jd3BDmP7qPsz0zQMJj+UD7EprF+AqAXcILnexw==",
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.28.5.tgz",
+			"integrity": "sha512-+bQy5WOI2V6LJZpPVxY+yp66XdZ2yifu0Mc1aP5CQKgjn4QM5IN2i5fAZ4xKop47pr8rpVhiAeu+nDQa12C8+g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.7",
-				"@babel/helper-validator-option": "^7.25.7",
-				"@babel/plugin-syntax-jsx": "^7.25.7",
-				"@babel/plugin-transform-modules-commonjs": "^7.25.7",
-				"@babel/plugin-transform-typescript": "^7.25.7"
+				"@babel/helper-plugin-utils": "^7.27.1",
+				"@babel/helper-validator-option": "^7.27.1",
+				"@babel/plugin-syntax-jsx": "^7.27.1",
+				"@babel/plugin-transform-modules-commonjs": "^7.27.1",
+				"@babel/plugin-transform-typescript": "^7.28.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1834,31 +1870,31 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.27.2",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-			"integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+			"version": "7.28.6",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+			"integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.27.1",
-				"@babel/parser": "^7.27.2",
-				"@babel/types": "^7.27.1"
+				"@babel/code-frame": "^7.28.6",
+				"@babel/parser": "^7.28.6",
+				"@babel/types": "^7.28.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
-			"integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+			"integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.27.1",
-				"@babel/generator": "^7.28.5",
+				"@babel/code-frame": "^7.29.0",
+				"@babel/generator": "^7.29.0",
 				"@babel/helper-globals": "^7.28.0",
-				"@babel/parser": "^7.28.5",
-				"@babel/template": "^7.27.2",
-				"@babel/types": "^7.28.5",
+				"@babel/parser": "^7.29.0",
+				"@babel/template": "^7.28.6",
+				"@babel/types": "^7.29.0",
 				"debug": "^4.3.1"
 			},
 			"engines": {
@@ -1866,9 +1902,9 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-			"integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+			"version": "7.29.0",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+			"integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
 			"license": "MIT",
 			"dependencies": {
 				"@babel/helper-string-parser": "^7.27.1",
@@ -2132,9 +2168,9 @@
 			}
 		},
 		"node_modules/@emnapi/core": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-			"integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+			"integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -2144,9 +2180,9 @@
 			}
 		},
 		"node_modules/@emnapi/runtime": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-			"integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -2252,6 +2288,13 @@
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true,
 			"license": "Python-2.0"
+		},
+		"node_modules/@eslint/eslintrc/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
 			"version": "1.1.14",
@@ -2391,9 +2434,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@hapi/tlds": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/@hapi/tlds/-/tlds-1.1.4.tgz",
-			"integrity": "sha512-Fq+20dxsxLaUn5jSSWrdtSRcIUba2JquuorF9UW1wIJS5cSUwxIsO2GIhaWynPRflvxSzFN+gxKte2HEW1OuoA==",
+			"version": "1.1.6",
+			"resolved": "https://registry.npmjs.org/@hapi/tlds/-/tlds-1.1.6.tgz",
+			"integrity": "sha512-xdi7A/4NZokvV0ewovme3aUO5kQhW9pQ2YD1hRqZGhhSi5rBv4usHYidVocXSi9eihYsznZxLtAiEYYUL6VBGw==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"engines": {
@@ -2425,6 +2468,13 @@
 			"engines": {
 				"node": ">=10.10.0"
 			}
+		},
+		"node_modules/@humanwhocodes/config-array/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
 			"version": "1.1.14",
@@ -2498,9 +2548,9 @@
 			}
 		},
 		"node_modules/@istanbuljs/schema": {
-			"version": "0.1.3",
-			"resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
-			"integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+			"integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -2589,19 +2639,19 @@
 			}
 		},
 		"node_modules/@jest/environment-jsdom-abstract": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/environment-jsdom-abstract/-/environment-jsdom-abstract-30.2.0.tgz",
-			"integrity": "sha512-kazxw2L9IPuZpQ0mEt9lu9Z98SqR74xcagANmMBU16X0lS23yPc0+S6hGLUz8kVRlomZEs/5S/Zlpqwf5yu6OQ==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment-jsdom-abstract/-/environment-jsdom-abstract-30.3.0.tgz",
+			"integrity": "sha512-0hNFs5N6We3DMCwobzI0ydhkY10sT1tZSC0AAiy+0g2Dt/qEWgrcV5BrMxPczhe41cxW4qm6X+jqZaUdpZIajA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/environment": "30.2.0",
-				"@jest/fake-timers": "30.2.0",
-				"@jest/types": "30.2.0",
+				"@jest/environment": "30.3.0",
+				"@jest/fake-timers": "30.3.0",
+				"@jest/types": "30.3.0",
 				"@types/jsdom": "^21.1.7",
 				"@types/node": "*",
-				"jest-mock": "30.2.0",
-				"jest-util": "30.2.0"
+				"jest-mock": "30.3.0",
+				"jest-util": "30.3.0"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -2617,34 +2667,34 @@
 			}
 		},
 		"node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/environment": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.2.0.tgz",
-			"integrity": "sha512-/QPTL7OBJQ5ac09UDRa3EQes4gt1FTEG/8jZ/4v5IVzx+Cv7dLxlVIvfvSVRiiX2drWyXeBjkMSR8hvOWSog5g==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.3.0.tgz",
+			"integrity": "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/fake-timers": "30.2.0",
-				"@jest/types": "30.2.0",
+				"@jest/fake-timers": "30.3.0",
+				"@jest/types": "30.3.0",
 				"@types/node": "*",
-				"jest-mock": "30.2.0"
+				"jest-mock": "30.3.0"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/fake-timers": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.2.0.tgz",
-			"integrity": "sha512-HI3tRLjRxAbBy0VO8dqqm7Hb2mIa8d5bg/NJkyQcOk7V118ObQML8RC5luTF/Zsg4474a+gDvhce7eTnP4GhYw==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.3.0.tgz",
+			"integrity": "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@sinonjs/fake-timers": "^13.0.0",
+				"@jest/types": "30.3.0",
+				"@sinonjs/fake-timers": "^15.0.0",
 				"@types/node": "*",
-				"jest-message-util": "30.2.0",
-				"jest-mock": "30.2.0",
-				"jest-util": "30.2.0"
+				"jest-message-util": "30.3.0",
+				"jest-mock": "30.3.0",
+				"jest-util": "30.3.0"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -2664,9 +2714,9 @@
 			}
 		},
 		"node_modules/@jest/environment-jsdom-abstract/node_modules/@jest/types": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.2.0.tgz",
-			"integrity": "sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+			"integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2683,16 +2733,16 @@
 			}
 		},
 		"node_modules/@jest/environment-jsdom-abstract/node_modules/@sinclair/typebox": {
-			"version": "0.34.46",
-			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.46.tgz",
-			"integrity": "sha512-kiW7CtS/NkdvTUjkjUJo7d5JsFfbJ14YjdhDk9KoEgK6nFjKNXZPrX0jfLA8ZlET4cFLHxOZ/0vFKOP+bOxIOQ==",
+			"version": "0.34.49",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+			"integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@jest/environment-jsdom-abstract/node_modules/@sinonjs/fake-timers": {
-			"version": "13.0.5",
-			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
-			"integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+			"version": "15.3.2",
+			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
+			"integrity": "sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -2713,9 +2763,9 @@
 			}
 		},
 		"node_modules/@jest/environment-jsdom-abstract/node_modules/ci-info": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
-			"integrity": "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+			"integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
 			"dev": true,
 			"funding": [
 				{
@@ -2729,19 +2779,19 @@
 			}
 		},
 		"node_modules/@jest/environment-jsdom-abstract/node_modules/jest-message-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
-			"integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
+			"integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.27.1",
-				"@jest/types": "30.2.0",
+				"@jest/types": "30.3.0",
 				"@types/stack-utils": "^2.0.3",
 				"chalk": "^4.1.2",
 				"graceful-fs": "^4.2.11",
-				"micromatch": "^4.0.8",
-				"pretty-format": "30.2.0",
+				"picomatch": "^4.0.3",
+				"pretty-format": "30.3.0",
 				"slash": "^3.0.0",
 				"stack-utils": "^2.0.6"
 			},
@@ -2750,33 +2800,33 @@
 			}
 		},
 		"node_modules/@jest/environment-jsdom-abstract/node_modules/jest-mock": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
-			"integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
+			"integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "30.2.0",
+				"@jest/types": "30.3.0",
 				"@types/node": "*",
-				"jest-util": "30.2.0"
+				"jest-util": "30.3.0"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/@jest/environment-jsdom-abstract/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+			"integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "30.2.0",
+				"@jest/types": "30.3.0",
 				"@types/node": "*",
 				"chalk": "^4.1.2",
 				"ci-info": "^4.2.0",
 				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
+				"picomatch": "^4.0.3"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -2796,9 +2846,9 @@
 			}
 		},
 		"node_modules/@jest/environment-jsdom-abstract/node_modules/pretty-format": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+			"integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3078,6 +3128,16 @@
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.0",
+				"@jridgewell/trace-mapping": "^0.3.24"
+			}
+		},
+		"node_modules/@jridgewell/remapping": {
+			"version": "2.3.5",
+			"resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+			"integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+			"license": "MIT",
+			"dependencies": {
+				"@jridgewell/gen-mapping": "^0.3.5",
 				"@jridgewell/trace-mapping": "^0.3.24"
 			}
 		},
@@ -3792,18 +3852,18 @@
 			}
 		},
 		"node_modules/@parcel/watcher": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
-			"integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
+			"integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
-				"detect-libc": "^1.0.3",
+				"detect-libc": "^2.0.3",
 				"is-glob": "^4.0.3",
-				"micromatch": "^4.0.5",
-				"node-addon-api": "^7.0.0"
+				"node-addon-api": "^7.0.0",
+				"picomatch": "^4.0.3"
 			},
 			"engines": {
 				"node": ">= 10.0.0"
@@ -3813,25 +3873,25 @@
 				"url": "https://opencollective.com/parcel"
 			},
 			"optionalDependencies": {
-				"@parcel/watcher-android-arm64": "2.5.1",
-				"@parcel/watcher-darwin-arm64": "2.5.1",
-				"@parcel/watcher-darwin-x64": "2.5.1",
-				"@parcel/watcher-freebsd-x64": "2.5.1",
-				"@parcel/watcher-linux-arm-glibc": "2.5.1",
-				"@parcel/watcher-linux-arm-musl": "2.5.1",
-				"@parcel/watcher-linux-arm64-glibc": "2.5.1",
-				"@parcel/watcher-linux-arm64-musl": "2.5.1",
-				"@parcel/watcher-linux-x64-glibc": "2.5.1",
-				"@parcel/watcher-linux-x64-musl": "2.5.1",
-				"@parcel/watcher-win32-arm64": "2.5.1",
-				"@parcel/watcher-win32-ia32": "2.5.1",
-				"@parcel/watcher-win32-x64": "2.5.1"
+				"@parcel/watcher-android-arm64": "2.5.6",
+				"@parcel/watcher-darwin-arm64": "2.5.6",
+				"@parcel/watcher-darwin-x64": "2.5.6",
+				"@parcel/watcher-freebsd-x64": "2.5.6",
+				"@parcel/watcher-linux-arm-glibc": "2.5.6",
+				"@parcel/watcher-linux-arm-musl": "2.5.6",
+				"@parcel/watcher-linux-arm64-glibc": "2.5.6",
+				"@parcel/watcher-linux-arm64-musl": "2.5.6",
+				"@parcel/watcher-linux-x64-glibc": "2.5.6",
+				"@parcel/watcher-linux-x64-musl": "2.5.6",
+				"@parcel/watcher-win32-arm64": "2.5.6",
+				"@parcel/watcher-win32-ia32": "2.5.6",
+				"@parcel/watcher-win32-x64": "2.5.6"
 			}
 		},
 		"node_modules/@parcel/watcher-android-arm64": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.1.tgz",
-			"integrity": "sha512-KF8+j9nNbUN8vzOFDpRMsaKBHZ/mcjEjMToVMJOhTozkDonQFFrRcfdLWn6yWKCmJKmdVxSgHiYvTCef4/qcBA==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
+			"integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
 			"cpu": [
 				"arm64"
 			],
@@ -3850,9 +3910,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-darwin-arm64": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.1.tgz",
-			"integrity": "sha512-eAzPv5osDmZyBhou8PoF4i6RQXAfeKL9tjb3QzYuccXFMQU0ruIc/POh30ePnaOyD1UXdlKguHBmsTs53tVoPw==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
+			"integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
 			"cpu": [
 				"arm64"
 			],
@@ -3871,9 +3931,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-darwin-x64": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.1.tgz",
-			"integrity": "sha512-1ZXDthrnNmwv10A0/3AJNZ9JGlzrF82i3gNQcWOzd7nJ8aj+ILyW1MTxVk35Db0u91oD5Nlk9MBiujMlwmeXZg==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
+			"integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
 			"cpu": [
 				"x64"
 			],
@@ -3892,9 +3952,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-freebsd-x64": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.1.tgz",
-			"integrity": "sha512-SI4eljM7Flp9yPuKi8W0ird8TI/JK6CSxju3NojVI6BjHsTyK7zxA9urjVjEKJ5MBYC+bLmMcbAWlZ+rFkLpJQ==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
+			"integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
 			"cpu": [
 				"x64"
 			],
@@ -3913,13 +3973,16 @@
 			}
 		},
 		"node_modules/@parcel/watcher-linux-arm-glibc": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.1.tgz",
-			"integrity": "sha512-RCdZlEyTs8geyBkkcnPWvtXLY44BCeZKmGYRtSgtwwnHR4dxfHRG3gR99XdMEdQ7KeiDdasJwwvNSF5jKtDwdA==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
+			"integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
 			"cpu": [
 				"arm"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3934,13 +3997,16 @@
 			}
 		},
 		"node_modules/@parcel/watcher-linux-arm-musl": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.1.tgz",
-			"integrity": "sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
+			"integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
 			"cpu": [
 				"arm"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3955,13 +4021,16 @@
 			}
 		},
 		"node_modules/@parcel/watcher-linux-arm64-glibc": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.1.tgz",
-			"integrity": "sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
+			"integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3976,13 +4045,16 @@
 			}
 		},
 		"node_modules/@parcel/watcher-linux-arm64-musl": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.1.tgz",
-			"integrity": "sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
+			"integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
 			"cpu": [
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -3997,13 +4069,16 @@
 			}
 		},
 		"node_modules/@parcel/watcher-linux-x64-glibc": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.1.tgz",
-			"integrity": "sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
+			"integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4018,13 +4093,16 @@
 			}
 		},
 		"node_modules/@parcel/watcher-linux-x64-musl": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.1.tgz",
-			"integrity": "sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
+			"integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4039,9 +4117,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-win32-arm64": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.1.tgz",
-			"integrity": "sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
+			"integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
 			"cpu": [
 				"arm64"
 			],
@@ -4060,9 +4138,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-win32-ia32": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.1.tgz",
-			"integrity": "sha512-c2KkcVN+NJmuA7CGlaGD1qJh1cLfDnQsHjE89E60vUEMlqduHGCdCLJCID5geFVM0dOtA3ZiIO8BoEQmzQVfpQ==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
+			"integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
 			"cpu": [
 				"ia32"
 			],
@@ -4081,9 +4159,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-win32-x64": {
-			"version": "2.5.1",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.1.tgz",
-			"integrity": "sha512-9lHBdJITeNR++EvSQVUcaZoWupyHfXe1jZvGZ06O/5MflPcuPLtEphScIBL+AiCWBO46tDSHzWyD0uDmmZqsgA==",
+			"version": "2.5.6",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
+			"integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
 			"cpu": [
 				"x64"
 			],
@@ -4099,6 +4177,20 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/parcel"
+			}
+		},
+		"node_modules/@parcel/watcher/node_modules/picomatch": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"dev": true,
+			"license": "MIT",
+			"optional": true,
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/jonschlinkert"
 			}
 		},
 		"node_modules/@paulirish/trace_engine": {
@@ -4235,9 +4327,9 @@
 			}
 		},
 		"node_modules/@puppeteer/browsers/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -4356,9 +4448,9 @@
 			}
 		},
 		"node_modules/@sinclair/typebox": {
-			"version": "0.27.8",
-			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-			"integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+			"version": "0.27.10",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+			"integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
 			"license": "MIT"
 		},
 		"node_modules/@sinonjs/commons": {
@@ -4878,9 +4970,22 @@
 			}
 		},
 		"node_modules/@types/express-serve-static-core": {
-			"version": "4.19.7",
-			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.7.tgz",
-			"integrity": "sha512-FvPtiIf1LfhzsaIXhv/PHan/2FeQBbtBDtfX2QfvPxdUelMDEckK08SM6nqo1MIZY3RUlfA+HV8+hFUSio78qg==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.1.1.tgz",
+			"integrity": "sha512-v4zIMr/cX7/d2BpAEX3KNKL/JrT1s43s96lLvvdTmza1oEvDudCqK9aF/djc/SWgy8Yh0h30TZx5VpzqFCxk5A==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/node": "*",
+				"@types/qs": "*",
+				"@types/range-parser": "*",
+				"@types/send": "*"
+			}
+		},
+		"node_modules/@types/express/node_modules/@types/express-serve-static-core": {
+			"version": "4.19.8",
+			"resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.8.tgz",
+			"integrity": "sha512-02S5fmqeoKzVZCHPZid4b8JH2eM5HzQLZWN2FohQEy/0eXTq8VXZfSN6Pcr3F6N9R/vNrj7cpgbhjie6m/1tCA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4991,9 +5096,9 @@
 			}
 		},
 		"node_modules/@types/node": {
-			"version": "20.19.33",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.33.tgz",
-			"integrity": "sha512-Rs1bVAIdBs5gbTIKza/tgpMuG1k3U/UMJLWecIMxNdJFDMzcM5LOiLVRYh3PilWEYDIeUDv7bpiHPLPsbydGcw==",
+			"version": "20.19.39",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.39.tgz",
+			"integrity": "sha512-orrrD74MBUyK8jOAD/r0+lfa1I2MO6I+vAkmAWzMYbCcgrN4lCrmK52gRFQq/JRxfYPfonkr4b0jcY7Olqdqbw==",
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~6.21.0"
@@ -5053,9 +5158,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/qs": {
-			"version": "6.14.0",
-			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
-			"integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
+			"version": "6.15.0",
+			"resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.15.0.tgz",
+			"integrity": "sha512-JawvT8iBVWpzTrz3EGw9BTQFg3BQNmwERdKE22vlTxawwtbyUSlMppvZYKLZzB5zgACXdXxbD3m1bXaMqP/9ow==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -5102,13 +5207,12 @@
 			"license": "MIT"
 		},
 		"node_modules/@types/send": {
-			"version": "0.17.6",
-			"resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
-			"integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+			"integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@types/mime": "^1",
 				"@types/node": "*"
 			}
 		},
@@ -5132,6 +5236,17 @@
 				"@types/http-errors": "*",
 				"@types/node": "*",
 				"@types/send": "<1"
+			}
+		},
+		"node_modules/@types/serve-static/node_modules/@types/send": {
+			"version": "0.17.6",
+			"resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
+			"integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/mime": "^1",
+				"@types/node": "*"
 			}
 		},
 		"node_modules/@types/shimmer": {
@@ -5970,13 +6085,13 @@
 			}
 		},
 		"node_modules/@wordpress/api-fetch": {
-			"version": "7.40.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.40.0.tgz",
-			"integrity": "sha512-u/PjrmuHlVo93u1FrUGJQNokMyc8RvC9o0mQboU8sLe9Hz288XSShdvY7hyZfroYtXGu81s/3KUHxUsTK4GGrA==",
+			"version": "7.44.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/api-fetch/-/api-fetch-7.44.0.tgz",
+			"integrity": "sha512-KZP5Y0AzUVPRbwCsp2MUNEjIyYPJdaa7ojzYyc/IVlaAlbXVdd0Ofk8UDf4l8PjtXkyyPs9pX9sFy5iNcrF2cQ==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/i18n": "^6.13.0",
-				"@wordpress/url": "^4.40.0"
+				"@wordpress/i18n": "^6.17.0",
+				"@wordpress/url": "^4.44.0"
 			},
 			"engines": {
 				"node": ">=18.12.0",
@@ -5984,9 +6099,9 @@
 			}
 		},
 		"node_modules/@wordpress/babel-preset-default": {
-			"version": "8.43.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.43.0.tgz",
-			"integrity": "sha512-L2EOVoc0EXlz/QJRW1KuJxiKtVntD5bqFzMTizPmNdwr6BIyVOWs7mDOCldTTCKcYcLSGMbTFj7F24rKNC4Cmw==",
+			"version": "8.44.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.44.0.tgz",
+			"integrity": "sha512-6EQW8ysiQkct2MolHlhyqXfZ/Vgl0Cu9dCeHfPEf7S/8575qua1GnuDSFzEqU/8TIrEG88f2e2qP/R7VRB+EwQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -5996,8 +6111,8 @@
 				"@babel/plugin-transform-runtime": "7.25.7",
 				"@babel/preset-env": "7.25.7",
 				"@babel/preset-typescript": "7.25.7",
-				"@wordpress/browserslist-config": "^6.43.0",
-				"@wordpress/warning": "^3.43.0",
+				"@wordpress/browserslist-config": "^6.44.0",
+				"@wordpress/warning": "^3.44.0",
 				"browserslist": "^4.21.10",
 				"core-js": "^3.31.0",
 				"react": "^18.3.0"
@@ -6005,6 +6120,37 @@
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
+			}
+		},
+		"node_modules/@wordpress/babel-preset-default/node_modules/@babel/core": {
+			"version": "7.25.7",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.7.tgz",
+			"integrity": "sha512-yJ474Zv3cwiSOO9nXJuqzvwEeM+chDuQ8GJirw+pZ91sCGCyOZ3dJkVE09fTV0VEVzXyLWhh3G/AolYTPX7Mow==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@ampproject/remapping": "^2.2.0",
+				"@babel/code-frame": "^7.25.7",
+				"@babel/generator": "^7.25.7",
+				"@babel/helper-compilation-targets": "^7.25.7",
+				"@babel/helper-module-transforms": "^7.25.7",
+				"@babel/helpers": "^7.25.7",
+				"@babel/parser": "^7.25.7",
+				"@babel/template": "^7.25.7",
+				"@babel/traverse": "^7.25.7",
+				"@babel/types": "^7.25.7",
+				"convert-source-map": "^2.0.0",
+				"debug": "^4.1.0",
+				"gensync": "^1.0.0-beta.2",
+				"json5": "^2.2.3",
+				"semver": "^6.3.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/babel"
 			}
 		},
 		"node_modules/@wordpress/babel-preset-default/node_modules/@babel/plugin-syntax-import-attributes": {
@@ -6043,10 +6189,142 @@
 				"@babel/core": "^7.0.0-0"
 			}
 		},
+		"node_modules/@wordpress/babel-preset-default/node_modules/@babel/preset-env": {
+			"version": "7.25.7",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.25.7.tgz",
+			"integrity": "sha512-Gibz4OUdyNqqLj+7OAvBZxOD7CklCtMA5/j0JgUEwOnaRULsPDXmic2iKxL2DX2vQduPR5wH2hjZas/Vr/Oc0g==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/compat-data": "^7.25.7",
+				"@babel/helper-compilation-targets": "^7.25.7",
+				"@babel/helper-plugin-utils": "^7.25.7",
+				"@babel/helper-validator-option": "^7.25.7",
+				"@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.25.7",
+				"@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.25.7",
+				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.25.7",
+				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.25.7",
+				"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.25.7",
+				"@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
+				"@babel/plugin-syntax-async-generators": "^7.8.4",
+				"@babel/plugin-syntax-class-properties": "^7.12.13",
+				"@babel/plugin-syntax-class-static-block": "^7.14.5",
+				"@babel/plugin-syntax-dynamic-import": "^7.8.3",
+				"@babel/plugin-syntax-export-namespace-from": "^7.8.3",
+				"@babel/plugin-syntax-import-assertions": "^7.25.7",
+				"@babel/plugin-syntax-import-attributes": "^7.25.7",
+				"@babel/plugin-syntax-import-meta": "^7.10.4",
+				"@babel/plugin-syntax-json-strings": "^7.8.3",
+				"@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
+				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+				"@babel/plugin-syntax-numeric-separator": "^7.10.4",
+				"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
+				"@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
+				"@babel/plugin-syntax-optional-chaining": "^7.8.3",
+				"@babel/plugin-syntax-private-property-in-object": "^7.14.5",
+				"@babel/plugin-syntax-top-level-await": "^7.14.5",
+				"@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
+				"@babel/plugin-transform-arrow-functions": "^7.25.7",
+				"@babel/plugin-transform-async-generator-functions": "^7.25.7",
+				"@babel/plugin-transform-async-to-generator": "^7.25.7",
+				"@babel/plugin-transform-block-scoped-functions": "^7.25.7",
+				"@babel/plugin-transform-block-scoping": "^7.25.7",
+				"@babel/plugin-transform-class-properties": "^7.25.7",
+				"@babel/plugin-transform-class-static-block": "^7.25.7",
+				"@babel/plugin-transform-classes": "^7.25.7",
+				"@babel/plugin-transform-computed-properties": "^7.25.7",
+				"@babel/plugin-transform-destructuring": "^7.25.7",
+				"@babel/plugin-transform-dotall-regex": "^7.25.7",
+				"@babel/plugin-transform-duplicate-keys": "^7.25.7",
+				"@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.25.7",
+				"@babel/plugin-transform-dynamic-import": "^7.25.7",
+				"@babel/plugin-transform-exponentiation-operator": "^7.25.7",
+				"@babel/plugin-transform-export-namespace-from": "^7.25.7",
+				"@babel/plugin-transform-for-of": "^7.25.7",
+				"@babel/plugin-transform-function-name": "^7.25.7",
+				"@babel/plugin-transform-json-strings": "^7.25.7",
+				"@babel/plugin-transform-literals": "^7.25.7",
+				"@babel/plugin-transform-logical-assignment-operators": "^7.25.7",
+				"@babel/plugin-transform-member-expression-literals": "^7.25.7",
+				"@babel/plugin-transform-modules-amd": "^7.25.7",
+				"@babel/plugin-transform-modules-commonjs": "^7.25.7",
+				"@babel/plugin-transform-modules-systemjs": "^7.25.7",
+				"@babel/plugin-transform-modules-umd": "^7.25.7",
+				"@babel/plugin-transform-named-capturing-groups-regex": "^7.25.7",
+				"@babel/plugin-transform-new-target": "^7.25.7",
+				"@babel/plugin-transform-nullish-coalescing-operator": "^7.25.7",
+				"@babel/plugin-transform-numeric-separator": "^7.25.7",
+				"@babel/plugin-transform-object-rest-spread": "^7.25.7",
+				"@babel/plugin-transform-object-super": "^7.25.7",
+				"@babel/plugin-transform-optional-catch-binding": "^7.25.7",
+				"@babel/plugin-transform-optional-chaining": "^7.25.7",
+				"@babel/plugin-transform-parameters": "^7.25.7",
+				"@babel/plugin-transform-private-methods": "^7.25.7",
+				"@babel/plugin-transform-private-property-in-object": "^7.25.7",
+				"@babel/plugin-transform-property-literals": "^7.25.7",
+				"@babel/plugin-transform-regenerator": "^7.25.7",
+				"@babel/plugin-transform-reserved-words": "^7.25.7",
+				"@babel/plugin-transform-shorthand-properties": "^7.25.7",
+				"@babel/plugin-transform-spread": "^7.25.7",
+				"@babel/plugin-transform-sticky-regex": "^7.25.7",
+				"@babel/plugin-transform-template-literals": "^7.25.7",
+				"@babel/plugin-transform-typeof-symbol": "^7.25.7",
+				"@babel/plugin-transform-unicode-escapes": "^7.25.7",
+				"@babel/plugin-transform-unicode-property-regex": "^7.25.7",
+				"@babel/plugin-transform-unicode-regex": "^7.25.7",
+				"@babel/plugin-transform-unicode-sets-regex": "^7.25.7",
+				"@babel/preset-modules": "0.1.6-no-external-plugins",
+				"babel-plugin-polyfill-corejs2": "^0.4.10",
+				"babel-plugin-polyfill-corejs3": "^0.10.6",
+				"babel-plugin-polyfill-regenerator": "^0.6.1",
+				"core-js-compat": "^3.38.1",
+				"semver": "^6.3.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@wordpress/babel-preset-default/node_modules/@babel/preset-typescript": {
+			"version": "7.25.7",
+			"resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.25.7.tgz",
+			"integrity": "sha512-rkkpaXJZOFN45Fb+Gki0c+KMIglk4+zZXOoMJuyEK8y8Kkc8Jd3BDmP7qPsz0zQMJj+UD7EprF+AqAXcILnexw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-plugin-utils": "^7.25.7",
+				"@babel/helper-validator-option": "^7.25.7",
+				"@babel/plugin-syntax-jsx": "^7.25.7",
+				"@babel/plugin-transform-modules-commonjs": "^7.25.7",
+				"@babel/plugin-transform-typescript": "^7.25.7"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/@wordpress/babel-preset-default/node_modules/babel-plugin-polyfill-corejs3": {
+			"version": "0.10.6",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.10.6.tgz",
+			"integrity": "sha512-b37+KR2i/khY5sKmWNVQAnitvquQbNdWy6lJdsr0kmquCKEEUgMKK4SboVM3HtfnZilfjr4MMQ7vY58FVWDtIA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/helper-define-polyfill-provider": "^0.6.2",
+				"core-js-compat": "^3.38.0"
+			},
+			"peerDependencies": {
+				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
+			}
+		},
 		"node_modules/@wordpress/base-styles": {
-			"version": "6.19.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.19.0.tgz",
-			"integrity": "sha512-SAZA6dhfC5X00s9PRrL9diY59WegiF0MuAWupkoKnYk3a2IAQbRUUTrh3j3wRyr08ljqefmifX5GR3hz/VwQaw==",
+			"version": "6.20.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.20.0.tgz",
+			"integrity": "sha512-Dsug4Zxz2xOFtK6CGThKYXwCqC9Yztw2STKQzwztrX4yW+o6iDbzkxpcwdDhsaVJs0Jt9A4LmJpZPh+pUozzLA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -6055,9 +6333,9 @@
 			}
 		},
 		"node_modules/@wordpress/browserslist-config": {
-			"version": "6.43.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.43.0.tgz",
-			"integrity": "sha512-W6Htq0S8g9RE02zwIB4HgbxwFeL9tijIleAIjp3pMuodP6ReRcWjvOX9O3DyfaRKrhl7JCFhT/M1RkKK3hQnYg==",
+			"version": "6.44.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.44.0.tgz",
+			"integrity": "sha512-lYtkO7U7ok9RfRBIHWvVWXhcOys6cQuLfwFr1bGuPTE6+LmVHmRyniMnImZlG8Jb3XE4pvH8gXT1ecXogpDI2Q==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -6066,9 +6344,9 @@
 			}
 		},
 		"node_modules/@wordpress/dependency-extraction-webpack-plugin": {
-			"version": "6.43.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.43.0.tgz",
-			"integrity": "sha512-4u7AvCEISGv9Q/sLHnV1+msZMKvHrDJ+R52Ezn3x2chIiOWFZWvr109BctwyUxvcn6SZgz9l0Ag88ffzdsjbqA==",
+			"version": "6.44.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.44.0.tgz",
+			"integrity": "sha512-bc6PfIUW//FxDu7DOuUoq2/oIQL2u8U33oDArFukTmyzf1fBWSIYKc2rpD3t3JMaWmnoiorlKgDpaFXfI6dCuA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -6090,9 +6368,9 @@
 			"license": "BSD"
 		},
 		"node_modules/@wordpress/e2e-test-utils-playwright": {
-			"version": "1.43.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.43.0.tgz",
-			"integrity": "sha512-suQCgtDVLRnGhdD7yWUVOTCGefW5perb0vTwQqWUbc/JyCdGnEztvGvpINXs7LV36U3YX7MYPEimCCcJc5frJA==",
+			"version": "1.44.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.44.0.tgz",
+			"integrity": "sha512-iUKHGH8TjW1s0cpkcHF6y/APOmy4YnwBfzdBNCITK4+4fuSZnTV7vZyzBU3adthGcBSMGQ9w8MTE2AzGLtlG3w==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -6112,15 +6390,15 @@
 			}
 		},
 		"node_modules/@wordpress/element": {
-			"version": "6.43.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.43.0.tgz",
-			"integrity": "sha512-eUWSBXnwO2y6ejg0RsZUnAk0E+tnuuCbCReZsZAgGJZykqek1Rt2hqxtvLZXPyuqzOR2XcR7k4hSf5l5BAJbhA==",
+			"version": "6.44.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.44.0.tgz",
+			"integrity": "sha512-kVCRSwGMPFu7oBcAzN0VzwFQw3mwctUb/TEHkGeG5An1Uus6olruGJyvFwkHNtO9WRCdTXXunUaSk0CIA9+Wig==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@types/react": "^18.3.27",
 				"@types/react-dom": "^18.3.1",
-				"@wordpress/escape-html": "^3.43.0",
+				"@wordpress/escape-html": "^3.44.0",
 				"change-case": "^4.1.2",
 				"is-plain-object": "^5.0.0",
 				"react": "^18.3.0",
@@ -6132,9 +6410,9 @@
 			}
 		},
 		"node_modules/@wordpress/escape-html": {
-			"version": "3.43.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.43.0.tgz",
-			"integrity": "sha512-Mo6b0y1vEnj/x7MVp+pe5IYYLs2X5ke5spuncrReO2Qb+iXw/d7694kpMGHyIVzBPj3ekwxEYezirW5OQrppOw==",
+			"version": "3.44.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.44.0.tgz",
+			"integrity": "sha512-nAEshSe6IYFr3G8sfY8o9pYNTRKvxocQ3DXs3KUesmdaEtrtJSlDmrMOI3FIgaYfv1PP6d+cDZpsygp6IZGo2w==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -6206,9 +6484,9 @@
 			}
 		},
 		"node_modules/@wordpress/hooks": {
-			"version": "4.40.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.40.0.tgz",
-			"integrity": "sha512-Lz89uHQaMKM2TAdwafCPJr6px5qodZt/wdLmRrGkrItvtbikLdf9l29BrjpSMmRbJY6jiYtOTVF4sg5rwJv2Pw==",
+			"version": "4.44.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.44.0.tgz",
+			"integrity": "sha512-6p2vFvoFaovqnKFnIoy6Kib2XJhTwaJ1VhMXp4tM2PhSLnFMXVm1TpcHeX/kH7E6sWKJACBrDR6FH2nGYMk5dA==",
 			"license": "GPL-2.0-or-later",
 			"engines": {
 				"node": ">=18.12.0",
@@ -6216,13 +6494,13 @@
 			}
 		},
 		"node_modules/@wordpress/i18n": {
-			"version": "6.13.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.13.0.tgz",
-			"integrity": "sha512-Yx882uFxcg6QpB13fv8UhvM6k5NwMQGfNXKB9SVSNL/APvDWn2m/n4n+5GZYi+wOV+KJLojQZbdRpHWCnX/jFg==",
+			"version": "6.17.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.17.0.tgz",
+			"integrity": "sha512-v1SLBweg7CRzQ+5+WSC1U93i8h9d3AoB0YBvMsd6gWI5vO8Zh4YKlEMexvrHQC++WN83egwqux84fWEdeU0MUA==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"@tannin/sprintf": "^1.3.2",
-				"@wordpress/hooks": "^4.40.0",
+				"@wordpress/hooks": "^4.44.0",
 				"gettext-parser": "^1.3.1",
 				"memize": "^2.1.0",
 				"tannin": "^1.2.0"
@@ -6236,9 +6514,9 @@
 			}
 		},
 		"node_modules/@wordpress/jest-console": {
-			"version": "8.43.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.43.0.tgz",
-			"integrity": "sha512-cKkbZGXAwRc9GkQ6U0QQs3aa6N/dV/F6QZdMdcObb3cg+jXSw1N6k86Q5ZFSlpzYXrBgqNl3I59xq1cRifAA4Q==",
+			"version": "8.44.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.44.0.tgz",
+			"integrity": "sha512-2Dawx6Qh2zr0ZlFByFmvkfCukb6CzCrCFnTnHImdiwlQ7wKcmTaIR3QPomJg6fTxiwgBiWn9yeiO7N97vJ59eg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
@@ -6254,13 +6532,13 @@
 			}
 		},
 		"node_modules/@wordpress/jest-preset-default": {
-			"version": "12.43.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.43.0.tgz",
-			"integrity": "sha512-PY5HoTa5oQ+oIzxh6f4J9h0P1mqNDC0MoJuLGaw4/Yu+zBSvQuW67B9D29pQcSuLsLMtaR6R1Um/HmU+M//3rw==",
+			"version": "12.44.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.44.0.tgz",
+			"integrity": "sha512-v5gj1/IdPfPoOOor/UZxvbuYQ8NYE1CV+De27Kf9w3MzTh1Z2KwuyZGA163X9OYMdQY36D2GfT2aa7p0RpWaFA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/jest-console": "^8.43.0",
+				"@wordpress/jest-console": "^8.44.0",
 				"babel-jest": "29.7.0"
 			},
 			"engines": {
@@ -6273,9 +6551,9 @@
 			}
 		},
 		"node_modules/@wordpress/npm-package-json-lint-config": {
-			"version": "5.43.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.43.0.tgz",
-			"integrity": "sha512-W98SP/WpGaQ9VziO1Ez88J5Lhr7l63d44RWtANueHvAndCMm2E6PgVSQTMEKUzimWI+RqQlY8AcHBx1DPyacxA==",
+			"version": "5.44.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.44.0.tgz",
+			"integrity": "sha512-XVu8wrLegxsJULb5lHd3Z8enlgQUWA9d+3Lsa+7AiyL5jUqDaMR1RKvHVvqAsCnlc2h2qoJiWUU7YLCVQNXd9Q==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -6287,13 +6565,13 @@
 			}
 		},
 		"node_modules/@wordpress/postcss-plugins-preset": {
-			"version": "5.43.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.43.0.tgz",
-			"integrity": "sha512-BlyQK1nb5TK0wLqnBiHpaz1ENngpZR8vf6gv3g2KCLstXJPl9WkM2g6GvKaDBOjodzVnGM2xs6tqlBlvfjKYxw==",
+			"version": "5.44.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.44.0.tgz",
+			"integrity": "sha512-D3GGSSmPKHUywK+pIHXsfnX6MXsjMb6rfQ33hX2hfOLZUR5VVt/DFJE3teinnyveQKOKeFcytiMr1pP2gH12RA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wordpress/base-styles": "^6.19.0",
+				"@wordpress/base-styles": "^6.20.0",
 				"autoprefixer": "^10.4.20",
 				"postcss-import": "^16.1.1"
 			},
@@ -6306,9 +6584,9 @@
 			}
 		},
 		"node_modules/@wordpress/prettier-config": {
-			"version": "4.43.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.43.0.tgz",
-			"integrity": "sha512-l52vxzgp61vfWq6fLIbAZl2efFMbEQ+BLGoekcyHw7h0rmg3u6YWTPdRRnzIfKAkSiArF8K80uvJ1eHYWiTMUg==",
+			"version": "4.44.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.44.0.tgz",
+			"integrity": "sha512-RT8Pc/dGOhMM9PwCsPamhkpIYx6zjTUDBIs/huVYKusByXImXQFoeZmaI3nK/UNus55woW6xyNNWdb2/nvvXgw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -6320,9 +6598,9 @@
 			}
 		},
 		"node_modules/@wordpress/private-apis": {
-			"version": "1.43.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.43.0.tgz",
-			"integrity": "sha512-ADZB20UjyQgdL43uFkFE9tm49URMRphydi+ngaxbAJnT/3n5x7WSzfXMBqrdQOuBpdy44O9yHz7JtzLXRapkjQ==",
+			"version": "1.44.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.44.0.tgz",
+			"integrity": "sha512-fTR1HRshYIrN4yau/Z+zxY+oRFnJz/LS8XGeXx43PT5O4B25+4kO41ApdS9FG56erg8HqUB6HoqDUcReT5pzlQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -6416,15 +6694,46 @@
 				}
 			}
 		},
+		"node_modules/@wordpress/scripts/node_modules/@babel/core": {
+			"version": "7.25.7",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.25.7.tgz",
+			"integrity": "sha512-yJ474Zv3cwiSOO9nXJuqzvwEeM+chDuQ8GJirw+pZ91sCGCyOZ3dJkVE09fTV0VEVzXyLWhh3G/AolYTPX7Mow==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@ampproject/remapping": "^2.2.0",
+				"@babel/code-frame": "^7.25.7",
+				"@babel/generator": "^7.25.7",
+				"@babel/helper-compilation-targets": "^7.25.7",
+				"@babel/helper-module-transforms": "^7.25.7",
+				"@babel/helpers": "^7.25.7",
+				"@babel/parser": "^7.25.7",
+				"@babel/template": "^7.25.7",
+				"@babel/traverse": "^7.25.7",
+				"@babel/types": "^7.25.7",
+				"convert-source-map": "^2.0.0",
+				"debug": "^4.1.0",
+				"gensync": "^1.0.0-beta.2",
+				"json5": "^2.2.3",
+				"semver": "^6.3.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/babel"
+			}
+		},
 		"node_modules/@wordpress/stylelint-config": {
-			"version": "23.35.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.35.0.tgz",
-			"integrity": "sha512-rBgpD6St0tJZpX5OSipeZ8oAFRU3hQZAfF1BT+DTU+O821YWtwYYiUsIA/z7jCCfL4gUuNA9/ndIAffKMQZOtg==",
+			"version": "23.36.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.36.0.tgz",
+			"integrity": "sha512-UJIrrJjdHD28tzjHZLS/KmaJjuaVZ5r5zYHguPSJfa5lxXP6JEqYPN4sQV6Ebjd5YtB4ZPKNVQDJHLQqtgRSdA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@stylistic/stylelint-plugin": "^3.0.1",
-				"@wordpress/theme": "^0.10.0",
+				"@wordpress/theme": "^0.11.0",
 				"stylelint-config-recommended": "^14.0.1",
 				"stylelint-config-recommended-scss": "^14.1.0"
 			},
@@ -6435,6 +6744,33 @@
 			"peerDependencies": {
 				"stylelint": "^16.8.2",
 				"stylelint-scss": "^6.4.0"
+			}
+		},
+		"node_modules/@wordpress/stylelint-config/node_modules/@wordpress/theme": {
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.11.0.tgz",
+			"integrity": "sha512-jXilt+3codfAEFRHvLpnULeOaaycwJByyv+m/TIlspZ4r0l4X9iA1KL7GkXOHz2AJWWvS7FUnS/GHBuIrUgAWg==",
+			"dev": true,
+			"license": "GPL-2.0-or-later",
+			"dependencies": {
+				"@wordpress/element": "^6.44.0",
+				"@wordpress/private-apis": "^1.44.0",
+				"colorjs.io": "^0.6.0",
+				"memize": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=18.12.0",
+				"npm": ">=8.19.2"
+			},
+			"peerDependencies": {
+				"react": "^18.0.0",
+				"react-dom": "^18.0.0",
+				"stylelint": "^16.8.2"
+			},
+			"peerDependenciesMeta": {
+				"stylelint": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@wordpress/theme": {
@@ -6465,9 +6801,9 @@
 			}
 		},
 		"node_modules/@wordpress/url": {
-			"version": "4.40.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.40.0.tgz",
-			"integrity": "sha512-DVAJlW7bdocKfQp8G7tS73vnobAC8TBbIHHdxeLQKwzT8mOkG4W/rpzN2KTxkiJKFXUu5in4F8a6T+Cy/Lt1eQ==",
+			"version": "4.44.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/url/-/url-4.44.0.tgz",
+			"integrity": "sha512-kWalXttgtRwFy4szBPX9dJcqHErRC0V9JuZ7uxdrxxdXl6WNv+lx8SYpLx12q3Zk6zNIw73M8E5wHON7eyXZZw==",
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
 				"remove-accents": "^0.5.0"
@@ -6478,9 +6814,9 @@
 			}
 		},
 		"node_modules/@wordpress/warning": {
-			"version": "3.43.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.43.0.tgz",
-			"integrity": "sha512-hZn++Njsops73oG2DHpjgriUkHTgk1ykvZtHEDllPSNx5Zf6S8KJ00kcToHjIj/4p1iiDjag2zSX5Yi9ySJHvg==",
+			"version": "3.44.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.44.0.tgz",
+			"integrity": "sha512-avxdbIYhDuUh2qi2oiq7KeqYOVv2RubqV8UI/Q7bctZSFSXJE8RQGSR/W2YjABeyWBIjlyX/U5lOxVs2PIfy/w==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -6535,9 +6871,9 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.15.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
-			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+			"version": "8.16.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -6581,9 +6917,9 @@
 			}
 		},
 		"node_modules/acorn-walk": {
-			"version": "8.3.4",
-			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
-			"integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
+			"version": "8.3.5",
+			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+			"integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6594,9 +6930,9 @@
 			}
 		},
 		"node_modules/adm-zip": {
-			"version": "0.5.16",
-			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.16.tgz",
-			"integrity": "sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==",
+			"version": "0.5.17",
+			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
+			"integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -6614,9 +6950,9 @@
 			}
 		},
 		"node_modules/ajv": {
-			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+			"integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7080,9 +7416,9 @@
 			}
 		},
 		"node_modules/autoprefixer": {
-			"version": "10.4.27",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
-			"integrity": "sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==",
+			"version": "10.5.0",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
+			"integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
 			"dev": true,
 			"funding": [
 				{
@@ -7100,8 +7436,8 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"browserslist": "^4.28.1",
-				"caniuse-lite": "^1.0.30001774",
+				"browserslist": "^4.28.2",
+				"caniuse-lite": "^1.0.30001787",
 				"fraction.js": "^5.3.4",
 				"picocolors": "^1.1.1",
 				"postcss-value-parser": "^4.2.0"
@@ -7133,9 +7469,9 @@
 			}
 		},
 		"node_modules/axe-core": {
-			"version": "4.11.2",
-			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.2.tgz",
-			"integrity": "sha512-byD6KPdvo72y/wj2T/4zGEvvlis+PsZsn/yPS3pEO+sFpcrqRpX/TJCxvVaEsNeMrfQbCr7w163YqoD9IYwHXw==",
+			"version": "4.11.3",
+			"resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.3.tgz",
+			"integrity": "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==",
 			"dev": true,
 			"license": "MPL-2.0",
 			"engines": {
@@ -7245,13 +7581,13 @@
 			}
 		},
 		"node_modules/babel-plugin-polyfill-corejs2": {
-			"version": "0.4.14",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.14.tgz",
-			"integrity": "sha512-Co2Y9wX854ts6U8gAAPXfn0GmAyctHuK8n0Yhfjd6t30g7yvKjspvvOo9yG+z52PZRgFErt7Ka2pYnXCjLKEpg==",
+			"version": "0.4.17",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.17.tgz",
+			"integrity": "sha512-aTyf30K/rqAsNwN76zYrdtx8obu0E4KoUME29B1xj+B3WxgvWkp943vYQ+z8Mv3lw9xHXMHpvSPOBxzAkIa94w==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/compat-data": "^7.27.7",
-				"@babel/helper-define-polyfill-provider": "^0.6.5",
+				"@babel/compat-data": "^7.28.6",
+				"@babel/helper-define-polyfill-provider": "^0.6.8",
 				"semver": "^6.3.1"
 			},
 			"peerDependencies": {
@@ -7259,25 +7595,25 @@
 			}
 		},
 		"node_modules/babel-plugin-polyfill-corejs3": {
-			"version": "0.10.6",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.10.6.tgz",
-			"integrity": "sha512-b37+KR2i/khY5sKmWNVQAnitvquQbNdWy6lJdsr0kmquCKEEUgMKK4SboVM3HtfnZilfjr4MMQ7vY58FVWDtIA==",
+			"version": "0.14.2",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.14.2.tgz",
+			"integrity": "sha512-coWpDLJ410R781Npmn/SIBZEsAetR4xVi0SxLMXPaMO4lSf1MwnkGYMtkFxew0Dn8B3/CpbpYxN0JCgg8mn67g==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-define-polyfill-provider": "^0.6.2",
-				"core-js-compat": "^3.38.0"
+				"@babel/helper-define-polyfill-provider": "^0.6.8",
+				"core-js-compat": "^3.48.0"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
 			}
 		},
 		"node_modules/babel-plugin-polyfill-regenerator": {
-			"version": "0.6.5",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.5.tgz",
-			"integrity": "sha512-ISqQ2frbiNU9vIJkzg7dlPpznPZ4jOiUQ1uSmB0fEHeowtN3COYRsXr/xexn64NpU13P06jc/L5TgiJXOgrbEg==",
+			"version": "0.6.8",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.6.8.tgz",
+			"integrity": "sha512-M762rNHfSF1EV3SLtnCJXFoQbbIIz0OyRwnCmV0KPC7qosSfCO0QLTSuJX3ayAebubhE6oYBAYPrBA5ljowaZg==",
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-define-polyfill-provider": "^0.6.5"
+				"@babel/helper-define-polyfill-provider": "^0.6.8"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -7326,10 +7662,14 @@
 			}
 		},
 		"node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-			"license": "MIT"
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "18 || 20 || >=22"
+			}
 		},
 		"node_modules/bare-events": {
 			"version": "2.8.2",
@@ -7347,12 +7687,11 @@
 			}
 		},
 		"node_modules/bare-fs": {
-			"version": "4.5.2",
-			"resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.5.2.tgz",
-			"integrity": "sha512-veTnRzkb6aPHOvSKIOy60KzURfBdUflr5VReI+NSaPL6xf+XLdONQgZgpYvUuZLVQ8dCqxpBAudaOM1+KpAUxw==",
+			"version": "4.7.1",
+			"resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.7.1.tgz",
+			"integrity": "sha512-WDRsyVN52eAx/lBamKD6uyw8H4228h/x0sGGGegOamM2cd7Pag88GfMQalobXI+HaEUxpCkbKQUDOQqt9wawRw==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"optional": true,
 			"dependencies": {
 				"bare-events": "^2.5.4",
 				"bare-path": "^3.0.0",
@@ -7373,12 +7712,11 @@
 			}
 		},
 		"node_modules/bare-os": {
-			"version": "3.6.2",
-			"resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.6.2.tgz",
-			"integrity": "sha512-T+V1+1srU2qYNBmJCXZkUY5vQ0B4FSlL3QDROnKQYOqeiQR8UbjNHlPa+TIbM4cuidiN9GaTaOZgSEgsvPbh5A==",
+			"version": "3.8.7",
+			"resolved": "https://registry.npmjs.org/bare-os/-/bare-os-3.8.7.tgz",
+			"integrity": "sha512-G4Gr1UsGeEy2qtDTZwL7JFLo2wapUarz7iTMcYcMFdS89AIQuBoyjgXZz0Utv7uHs3xA9LckhVbeBi8lEQrC+w==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"optional": true,
 			"engines": {
 				"bare": ">=1.14.0"
 			}
@@ -7389,26 +7727,29 @@
 			"integrity": "sha512-tyfW2cQcB5NN8Saijrhqn0Zh7AnFNsnczRcuWODH0eYAXBsJ5gVxAUuNr7tsHSC6IZ77cA0SitzT+s47kot8Mw==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"optional": true,
 			"dependencies": {
 				"bare-os": "^3.0.1"
 			}
 		},
 		"node_modules/bare-stream": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.7.0.tgz",
-			"integrity": "sha512-oyXQNicV1y8nc2aKffH+BUHFRXmx6VrPzlnaEvMhram0nPBrKcEdcyBg5r08D0i8VxngHFAiVyn1QKXpSG0B8A==",
+			"version": "2.13.0",
+			"resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.0.tgz",
+			"integrity": "sha512-3zAJRZMDFGjdn+RVnNpF9kuELw+0Fl3lpndM4NcEOhb9zwtSo/deETfuIwMSE5BXanA0FrN1qVjffGwAg2Y7EA==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"optional": true,
 			"dependencies": {
-				"streamx": "^2.21.0"
+				"streamx": "^2.25.0",
+				"teex": "^1.0.1"
 			},
 			"peerDependencies": {
+				"bare-abort-controller": "*",
 				"bare-buffer": "*",
 				"bare-events": "*"
 			},
 			"peerDependenciesMeta": {
+				"bare-abort-controller": {
+					"optional": true
+				},
 				"bare-buffer": {
 					"optional": true
 				},
@@ -7418,12 +7759,11 @@
 			}
 		},
 		"node_modules/bare-url": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.3.2.tgz",
-			"integrity": "sha512-ZMq4gd9ngV5aTMa5p9+UfY0b3skwhHELaDkhEHetMdX0LRkW9kzaym4oo/Eh+Ghm0CCDuMTsRIGM/ytUc1ZYmw==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.0.tgz",
+			"integrity": "sha512-NSTU5WN+fy/L0DDenfE8SXQna4voXuW0FHM7wH8i3/q9khUSchfPbPezO4zSFMnDGIf9YE+mt/RWhZgNRKRIXA==",
 			"dev": true,
 			"license": "Apache-2.0",
-			"optional": true,
 			"dependencies": {
 				"bare-path": "^3.0.0"
 			}
@@ -7450,12 +7790,15 @@
 			"license": "MIT"
 		},
 		"node_modules/baseline-browser-mapping": {
-			"version": "2.9.10",
-			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.10.tgz",
-			"integrity": "sha512-2VIKvDx8Z1a9rTB2eCkdPE5nSe28XnA+qivGnWHoB40hMMt/h1hSz0960Zqsn6ZyxWXUie0EBdElKv8may20AA==",
+			"version": "2.10.19",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.19.tgz",
+			"integrity": "sha512-qCkNLi2sfBOn8XhZQ0FXsT1Ki/Yo5P90hrkRamVFRS7/KV9hpfA4HkoWNU152+8w0zPjnxo5psx5NL3PSGgv5g==",
 			"license": "Apache-2.0",
 			"bin": {
-				"baseline-browser-mapping": "dist/cli.js"
+				"baseline-browser-mapping": "dist/cli.cjs"
+			},
+			"engines": {
+				"node": ">=6.0.0"
 			}
 		},
 		"node_modules/basic-ftp": {
@@ -7584,16 +7927,6 @@
 				"node": "18 || 20 || >=22"
 			}
 		},
-		"node_modules/brace-expansion/node_modules/balanced-match": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "18 || 20 || >=22"
-			}
-		},
 		"node_modules/braces": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
@@ -7607,9 +7940,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.28.1",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-			"integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+			"version": "4.28.2",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+			"integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -7626,11 +7959,11 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"baseline-browser-mapping": "^2.9.0",
-				"caniuse-lite": "^1.0.30001759",
-				"electron-to-chromium": "^1.5.263",
-				"node-releases": "^2.0.27",
-				"update-browserslist-db": "^1.2.0"
+				"baseline-browser-mapping": "^2.10.12",
+				"caniuse-lite": "^1.0.30001782",
+				"electron-to-chromium": "^1.5.328",
+				"node-releases": "^2.0.36",
+				"update-browserslist-db": "^1.2.3"
 			},
 			"bin": {
 				"browserslist": "cli.js"
@@ -7863,9 +8196,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001787",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001787.tgz",
-			"integrity": "sha512-mNcrMN9KeI68u7muanUpEejSLghOKlVhRqS/Za2IeyGllJ9I9otGpR9g3nsw7n4W378TE/LyIteA0+/FOZm4Kg==",
+			"version": "1.0.30001788",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
+			"integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -8429,12 +8762,12 @@
 			}
 		},
 		"node_modules/core-js-compat": {
-			"version": "3.47.0",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.47.0.tgz",
-			"integrity": "sha512-IGfuznZ/n7Kp9+nypamBhvwdwLsW6KC8IOaURw2doAK5e98AG3acVLdh0woOnEqCfUtS+Vu882JE4k/DAm3ItQ==",
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.49.0.tgz",
+			"integrity": "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==",
 			"license": "MIT",
 			"dependencies": {
-				"browserslist": "^4.28.0"
+				"browserslist": "^4.28.1"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -8442,9 +8775,9 @@
 			}
 		},
 		"node_modules/core-js-pure": {
-			"version": "3.47.0",
-			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.47.0.tgz",
-			"integrity": "sha512-BcxeDbzUrRnXGYIVAGFtcGQVNpFcUhVjr6W7F8XktvQW2iJP9e66GP6xdKotCRFlrxBvNIBrhwKteRXqMV86Nw==",
+			"version": "3.49.0",
+			"resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.49.0.tgz",
+			"integrity": "sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -8551,9 +8884,9 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/css-declaration-sorter": {
-			"version": "7.3.0",
-			"resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.3.0.tgz",
-			"integrity": "sha512-LQF6N/3vkAMYF4xoHLJfG718HRJh34Z8BnNhd6bosOMIVjMlhuZK5++oZa3uYAgrI5+7x2o27gUqTR2U/KjUOQ==",
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.4.0.tgz",
+			"integrity": "sha512-LTuzjPoyA2vMGKKcaOqKSp7Ub2eGrNfKiZH4LpezxpNrsICGCSFvsQOI29psISxNZtaXibkC2CXzrQ5enMeGGw==",
 			"dev": true,
 			"license": "ISC",
 			"engines": {
@@ -8610,9 +8943,9 @@
 			}
 		},
 		"node_modules/css-loader/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -9130,17 +9463,14 @@
 			}
 		},
 		"node_modules/detect-libc": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-			"integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+			"integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"optional": true,
-			"bin": {
-				"detect-libc": "bin/detect-libc.js"
-			},
 			"engines": {
-				"node": ">=0.10"
+				"node": ">=8"
 			}
 		},
 		"node_modules/detect-newline": {
@@ -9345,9 +9675,9 @@
 			"license": "MIT"
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.267",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.267.tgz",
-			"integrity": "sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==",
+			"version": "1.5.339",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.339.tgz",
+			"integrity": "sha512-Is+0BBHJ4NrdpAYiperrmp53pLywG/yV/6lIMTAnhxvzj/Cmn5Q/ogSHC6AKe7X+8kPLxxFk0cs5oc/3j/fxIg==",
 			"license": "ISC"
 		},
 		"node_modules/emittery": {
@@ -9410,14 +9740,14 @@
 			}
 		},
 		"node_modules/enhanced-resolve": {
-			"version": "5.18.4",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.18.4.tgz",
-			"integrity": "sha512-LgQMM4WXU3QI+SYgEc2liRgznaD5ojbmY3sb8LxyguVkIg5FxdpTkvk72te2R38/TGKxH634oLxXRGY6d7AP+Q==",
+			"version": "5.20.1",
+			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
+			"integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"graceful-fs": "^4.2.4",
-				"tapable": "^2.2.0"
+				"tapable": "^2.3.0"
 			},
 			"engines": {
 				"node": ">=10.13.0"
@@ -9576,7 +9906,6 @@
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
 			"integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -9977,6 +10306,13 @@
 				"eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
 			}
 		},
+		"node_modules/eslint-plugin-import/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/eslint-plugin-import/node_modules/brace-expansion": {
 			"version": "1.1.14",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
@@ -10248,6 +10584,13 @@
 				"eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9"
 			}
 		},
+		"node_modules/eslint-plugin-jsx-a11y/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
 			"version": "1.1.14",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
@@ -10365,6 +10708,13 @@
 				"eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0"
 			}
 		},
+		"node_modules/eslint-plugin-react/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/eslint-plugin-react/node_modules/brace-expansion": {
 			"version": "1.1.14",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
@@ -10466,6 +10816,13 @@
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true,
 			"license": "Python-2.0"
+		},
+		"node_modules/eslint/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/eslint/node_modules/brace-expansion": {
 			"version": "1.1.14",
@@ -11224,9 +11581,9 @@
 			"license": "ISC"
 		},
 		"node_modules/follow-redirects": {
-			"version": "1.15.11",
-			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-			"integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+			"version": "1.16.0",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+			"integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
 			"dev": true,
 			"funding": [
 				{
@@ -11365,9 +11722,9 @@
 			"license": "ISC"
 		},
 		"node_modules/fsevents": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+			"integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"optional": true,
@@ -11553,9 +11910,9 @@
 			}
 		},
 		"node_modules/get-tsconfig": {
-			"version": "4.13.7",
-			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.7.tgz",
-			"integrity": "sha512-7tN6rFgBlMgpBML5j8typ92BKFi2sFQvIdpAqLA2beia5avZDrMs0FLZiM5etShWq5irVyGcGMEA1jcDaK7A/Q==",
+			"version": "4.14.0",
+			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+			"integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -11594,7 +11951,7 @@
 			"version": "7.2.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
 			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-			"deprecated": "Glob versions prior to v9 are no longer supported",
+			"deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
 			"license": "ISC",
 			"dependencies": {
 				"fs.realpath": "^1.0.0",
@@ -11631,10 +11988,16 @@
 			"dev": true,
 			"license": "BSD-2-Clause"
 		},
+		"node_modules/glob/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"license": "MIT"
+		},
 		"node_modules/glob/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0",
@@ -12028,6 +12391,16 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/hpack.js/node_modules/string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"safe-buffer": "~5.1.0"
+			}
+		},
 		"node_modules/html-encoding-sniffer": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
@@ -12248,9 +12621,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/ignore": {
-			"version": "5.2.4",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-			"integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+			"version": "5.3.2",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -12270,10 +12643,17 @@
 				"node": ">=10"
 			}
 		},
+		"node_modules/ignore-walk/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/ignore-walk/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -13423,16 +13803,14 @@
 			}
 		},
 		"node_modules/jest-environment-jsdom": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-30.2.0.tgz",
-			"integrity": "sha512-zbBTiqr2Vl78pKp/laGBREYzbZx9ZtqPjOK4++lL4BNDhxRnahg51HtoDrk9/VjIy9IthNEWdKVd7H5bqBhiWQ==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-environment-jsdom/-/jest-environment-jsdom-30.3.0.tgz",
+			"integrity": "sha512-RLEOJy6ip1lpw0yqJ8tB3i88FC7VBz7i00Zvl2qF71IdxjS98gC9/0SPWYIBVXHm5hgCYK0PAlSlnHGGy9RoMg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/environment": "30.2.0",
-				"@jest/environment-jsdom-abstract": "30.2.0",
-				"@types/jsdom": "^21.1.7",
-				"@types/node": "*",
+				"@jest/environment": "30.3.0",
+				"@jest/environment-jsdom-abstract": "30.3.0",
 				"jsdom": "^26.1.0"
 			},
 			"engines": {
@@ -13448,34 +13826,34 @@
 			}
 		},
 		"node_modules/jest-environment-jsdom/node_modules/@jest/environment": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.2.0.tgz",
-			"integrity": "sha512-/QPTL7OBJQ5ac09UDRa3EQes4gt1FTEG/8jZ/4v5IVzx+Cv7dLxlVIvfvSVRiiX2drWyXeBjkMSR8hvOWSog5g==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/environment/-/environment-30.3.0.tgz",
+			"integrity": "sha512-SlLSF4Be735yQXyh2+mctBOzNDx5s5uLv88/j8Qn1wH679PDcwy67+YdADn8NJnGjzlXtN62asGH/T4vWOkfaw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/fake-timers": "30.2.0",
-				"@jest/types": "30.2.0",
+				"@jest/fake-timers": "30.3.0",
+				"@jest/types": "30.3.0",
 				"@types/node": "*",
-				"jest-mock": "30.2.0"
+				"jest-mock": "30.3.0"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-environment-jsdom/node_modules/@jest/fake-timers": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.2.0.tgz",
-			"integrity": "sha512-HI3tRLjRxAbBy0VO8dqqm7Hb2mIa8d5bg/NJkyQcOk7V118ObQML8RC5luTF/Zsg4474a+gDvhce7eTnP4GhYw==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-30.3.0.tgz",
+			"integrity": "sha512-WUQDs8SOP9URStX1DzhD425CqbN/HxUYCTwVrT8sTVBfMvFqYt/s61EK5T05qnHu0po6RitXIvP9otZxYDzTGQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "30.2.0",
-				"@sinonjs/fake-timers": "^13.0.0",
+				"@jest/types": "30.3.0",
+				"@sinonjs/fake-timers": "^15.0.0",
 				"@types/node": "*",
-				"jest-message-util": "30.2.0",
-				"jest-mock": "30.2.0",
-				"jest-util": "30.2.0"
+				"jest-message-util": "30.3.0",
+				"jest-mock": "30.3.0",
+				"jest-util": "30.3.0"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -13495,9 +13873,9 @@
 			}
 		},
 		"node_modules/jest-environment-jsdom/node_modules/@jest/types": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.2.0.tgz",
-			"integrity": "sha512-H9xg1/sfVvyfU7o3zMfBEjQ1gcsdeTMgqHoYdN79tuLqfTtuu7WckRA1R5whDwOzxaZAeMKTYWqP+WCAi0CHsg==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-30.3.0.tgz",
+			"integrity": "sha512-JHm87k7bA33hpBngtU8h6UBub/fqqA9uXfw+21j5Hmk7ooPHlboRNxHq0JcMtC+n8VJGP1mcfnD3Mk+XKe1oSw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -13514,16 +13892,16 @@
 			}
 		},
 		"node_modules/jest-environment-jsdom/node_modules/@sinclair/typebox": {
-			"version": "0.34.46",
-			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.46.tgz",
-			"integrity": "sha512-kiW7CtS/NkdvTUjkjUJo7d5JsFfbJ14YjdhDk9KoEgK6nFjKNXZPrX0jfLA8ZlET4cFLHxOZ/0vFKOP+bOxIOQ==",
+			"version": "0.34.49",
+			"resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.49.tgz",
+			"integrity": "sha512-brySQQs7Jtn0joV8Xh9ZV/hZb9Ozb0pmazDIASBkYKCjXrXU3mpcFahmK/z4YDhGkQvP9mWJbVyahdtU5wQA+A==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/jest-environment-jsdom/node_modules/@sinonjs/fake-timers": {
-			"version": "13.0.5",
-			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-13.0.5.tgz",
-			"integrity": "sha512-36/hTbH2uaWuGVERyC6da9YwGWnzUZXuPro/F2LfsdOsLnCojz/iSH8MxUt/FD2S5XBSVPhmArFUXcpCQ2Hkiw==",
+			"version": "15.3.2",
+			"resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-15.3.2.tgz",
+			"integrity": "sha512-mrn35Jl2pCpns+mE3HaZa1yPN5EYCRgiMI+135COjr2hr8Cls9DXqIZ57vZe2cz7y2XVSq92tcs6kGQcT1J8Rw==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -13544,9 +13922,9 @@
 			}
 		},
 		"node_modules/jest-environment-jsdom/node_modules/ci-info": {
-			"version": "4.3.1",
-			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
-			"integrity": "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==",
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+			"integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
 			"dev": true,
 			"funding": [
 				{
@@ -13560,19 +13938,19 @@
 			}
 		},
 		"node_modules/jest-environment-jsdom/node_modules/jest-message-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.2.0.tgz",
-			"integrity": "sha512-y4DKFLZ2y6DxTWD4cDe07RglV88ZiNEdlRfGtqahfbIjfsw1nMCPx49Uev4IA/hWn3sDKyAnSPwoYSsAEdcimw==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-30.3.0.tgz",
+			"integrity": "sha512-Z/j4Bo+4ySJ+JPJN3b2Qbl9hDq3VrXmnjjGEWD/x0BCXeOXPTV1iZYYzl2X8c1MaCOL+ewMyNBcm88sboE6YWw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.27.1",
-				"@jest/types": "30.2.0",
+				"@jest/types": "30.3.0",
 				"@types/stack-utils": "^2.0.3",
 				"chalk": "^4.1.2",
 				"graceful-fs": "^4.2.11",
-				"micromatch": "^4.0.8",
-				"pretty-format": "30.2.0",
+				"picomatch": "^4.0.3",
+				"pretty-format": "30.3.0",
 				"slash": "^3.0.0",
 				"stack-utils": "^2.0.6"
 			},
@@ -13581,33 +13959,33 @@
 			}
 		},
 		"node_modules/jest-environment-jsdom/node_modules/jest-mock": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.2.0.tgz",
-			"integrity": "sha512-JNNNl2rj4b5ICpmAcq+WbLH83XswjPbjH4T7yvGzfAGCPh1rw+xVNbtk+FnRslvt9lkCcdn9i1oAoKUuFsOxRw==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-30.3.0.tgz",
+			"integrity": "sha512-OTzICK8CpE+t4ndhKrwlIdbM6Pn8j00lvmSmq5ejiO+KxukbLjgOflKWMn3KE34EZdQm5RqTuKj+5RIEniYhog==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "30.2.0",
+				"@jest/types": "30.3.0",
 				"@types/node": "*",
-				"jest-util": "30.2.0"
+				"jest-util": "30.3.0"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
 		"node_modules/jest-environment-jsdom/node_modules/jest-util": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.2.0.tgz",
-			"integrity": "sha512-QKNsM0o3Xe6ISQU869e+DhG+4CK/48aHYdJZGlFQVTjnbvgpcKyxpzk29fGiO7i/J8VENZ+d2iGnSsvmuHywlA==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/jest-util/-/jest-util-30.3.0.tgz",
+			"integrity": "sha512-/jZDa00a3Sz7rdyu55NLrQCIrbyIkbBxareejQI315f/i8HjYN+ZWsDLLpoQSiUIEIyZF/R8fDg3BmB8AtHttg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "30.2.0",
+				"@jest/types": "30.3.0",
 				"@types/node": "*",
 				"chalk": "^4.1.2",
 				"ci-info": "^4.2.0",
 				"graceful-fs": "^4.2.11",
-				"picomatch": "^4.0.2"
+				"picomatch": "^4.0.3"
 			},
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
@@ -13627,9 +14005,9 @@
 			}
 		},
 		"node_modules/jest-environment-jsdom/node_modules/pretty-format": {
-			"version": "30.2.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.2.0.tgz",
-			"integrity": "sha512-9uBdv/B4EefsuAL+pWqueZyZS2Ba+LxfFeQ9DN14HU4bN8bhaxKdkpjpB6fs9+pSjIBu+FXQHImEg8j/Lw0+vA==",
+			"version": "30.3.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-30.3.0.tgz",
+			"integrity": "sha512-oG4T3wCbfeuvljnyAzhBvpN45E8iOTXCU/TD3zXW80HA3dQ4ahdqMkWGiPWZvjpQwlbyHrPTWUAqUzGzv4l1JQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -14032,9 +14410,9 @@
 			}
 		},
 		"node_modules/joi": {
-			"version": "18.0.2",
-			"resolved": "https://registry.npmjs.org/joi/-/joi-18.0.2.tgz",
-			"integrity": "sha512-RuCOQMIt78LWnktPoeBL0GErkNaJPTBGcYuyaBvUOQSpcpcLfWrHPPihYdOGbV5pam9VTWbeoF7TsGiHugcjGA==",
+			"version": "18.1.2",
+			"resolved": "https://registry.npmjs.org/joi/-/joi-18.1.2.tgz",
+			"integrity": "sha512-rF5MAmps5esSlhCA+N1b6IYHDw9j/btzGaqfgie522jS02Ju/HXBxamlXVlKEHAxoMKQL77HWI8jlqWsFuekZA==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -14044,7 +14422,7 @@
 				"@hapi/pinpoint": "^2.0.1",
 				"@hapi/tlds": "^1.1.1",
 				"@hapi/topo": "^6.0.2",
-				"@standard-schema/spec": "^1.0.0"
+				"@standard-schema/spec": "^1.1.0"
 			},
 			"engines": {
 				"node": ">= 20"
@@ -14289,9 +14667,9 @@
 			}
 		},
 		"node_modules/launch-editor": {
-			"version": "2.12.0",
-			"resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.12.0.tgz",
-			"integrity": "sha512-giOHXoOtifjdHqUamwKq6c49GzBdLjvxrd2D+Q4V6uOHopJv7p9VJxikDsQ/CBXZbEITgUqSVHXLTG3VhPP1Dg==",
+			"version": "2.13.2",
+			"resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.13.2.tgz",
+			"integrity": "sha512-4VVDnbOpLXy/s8rdRCSXb+zfMeFR0WlJWpET1iA9CQdlZDfwyLjUuGQzXU4VeOoey6AicSAluWan7Etga6Kcmg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -14425,16 +14803,16 @@
 			}
 		},
 		"node_modules/lighthouse/node_modules/puppeteer-core": {
-			"version": "24.40.0",
-			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.40.0.tgz",
-			"integrity": "sha512-MWL3XbUCfVgGR0gRsidzT6oKJT2QydPLhMITU6HoVWiiv4gkb6gJi3pcdAa8q4HwjBTbqISOWVP4aJiiyUJvag==",
+			"version": "24.41.0",
+			"resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.41.0.tgz",
+			"integrity": "sha512-rLIUri7E/NQ3APSEYCCozaSJx0u8Tu9wxO6BJwnvXmIgILSK3L0TombaVh3izp1njAGrO6H2ru0hcIrLF+gWLw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@puppeteer/browsers": "2.13.0",
 				"chromium-bidi": "14.0.0",
 				"debug": "^4.4.3",
-				"devtools-protocol": "0.0.1581282",
+				"devtools-protocol": "0.0.1595872",
 				"typed-query-selector": "^2.12.1",
 				"webdriver-bidi-protocol": "0.4.1",
 				"ws": "^8.19.0"
@@ -14458,9 +14836,9 @@
 			}
 		},
 		"node_modules/lighthouse/node_modules/puppeteer-core/node_modules/devtools-protocol": {
-			"version": "0.0.1581282",
-			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1581282.tgz",
-			"integrity": "sha512-nv7iKtNZQshSW2hKzYNr46nM/Cfh5SEvE2oV0/SEGgc9XupIY5ggf84Cz8eJIkBce7S3bmTAauFD6aysMpnqsQ==",
+			"version": "0.0.1595872",
+			"resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1595872.tgz",
+			"integrity": "sha512-kRfgp8vWVjBu/fbYCiVFiOqsCk3CrMKEo3WbgGT2NXK2dG7vawWPBljixajVgGK9II8rDO9G0oD0zLt3I1daRg==",
 			"dev": true,
 			"license": "BSD-3-Clause"
 		},
@@ -14857,10 +15235,17 @@
 			"dev": true,
 			"license": "Python-2.0"
 		},
+		"node_modules/markdownlint-cli/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/markdownlint-cli/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -14876,6 +15261,16 @@
 			"license": "MIT",
 			"engines": {
 				"node": "^12.20.0 || >=14"
+			}
+		},
+		"node_modules/markdownlint-cli/node_modules/ignore": {
+			"version": "5.2.4",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
+			"integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
 			}
 		},
 		"node_modules/markdownlint-cli/node_modules/js-yaml": {
@@ -15160,9 +15555,9 @@
 			}
 		},
 		"node_modules/mini-css-extract-plugin": {
-			"version": "2.9.4",
-			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.9.4.tgz",
-			"integrity": "sha512-ZWYT7ln73Hptxqxk2DxPU9MmapXRhxkJD6tkSR04dnQxm8BGu2hzgKLugK5yySD97u/8yy7Ma7E76k9ZdvtjkQ==",
+			"version": "2.10.2",
+			"resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-2.10.2.tgz",
+			"integrity": "sha512-AOSS0IdEB95ayVkxn5oGzNQwqAi2J0Jb/kKm43t7H73s8+f5873g0yuj0PNvK4dO75mu5DHg4nlgp4k6Kga8eg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -15376,9 +15771,9 @@
 			"license": "MIT"
 		},
 		"node_modules/netmask": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz",
-			"integrity": "sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/netmask/-/netmask-2.1.1.tgz",
+			"integrity": "sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -15440,9 +15835,9 @@
 			"license": "MIT"
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.27",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-			"integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+			"version": "2.0.37",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+			"integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
 			"license": "MIT"
 		},
 		"node_modules/normalize-package-data": {
@@ -16128,9 +16523,9 @@
 			"license": "MIT"
 		},
 		"node_modules/path-to-regexp": {
-			"version": "0.1.12",
-			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
-			"integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+			"version": "0.1.13",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+			"integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -16360,6 +16755,22 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/playwright/node_modules/fsevents": {
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+			"dev": true,
+			"hasInstallScript": true,
+			"license": "MIT",
+			"optional": true,
+			"os": [
+				"darwin"
+			],
+			"peer": true,
+			"engines": {
+				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+			}
+		},
 		"node_modules/plur": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/plur/-/plur-4.0.0.tgz",
@@ -16387,9 +16798,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.6",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-			"integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+			"version": "8.5.10",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+			"integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -16579,9 +16990,9 @@
 			}
 		},
 		"node_modules/postcss-loader/node_modules/semver": {
-			"version": "7.7.3",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-			"integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+			"version": "7.7.4",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -17323,9 +17734,9 @@
 			"license": "MIT"
 		},
 		"node_modules/pump": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
-			"integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
+			"version": "3.0.4",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+			"integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -17771,9 +18182,9 @@
 			"license": "MIT"
 		},
 		"node_modules/regjsparser": {
-			"version": "0.13.0",
-			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.0.tgz",
-			"integrity": "sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==",
+			"version": "0.13.1",
+			"resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.13.1.tgz",
+			"integrity": "sha512-dLsljMd9sqwRkby8zhO1gSg3PnJIBFid8f4CQj/sXx+7cKx+E7u0PKhZ+U4wmhx7EfmtvnA318oVaIkAB1lRJw==",
 			"license": "BSD-2-Clause",
 			"dependencies": {
 				"jsesc": "~3.1.0"
@@ -17841,11 +18252,12 @@
 			"license": "MIT"
 		},
 		"node_modules/resolve": {
-			"version": "1.22.11",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
-			"integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+			"version": "1.22.12",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+			"integrity": "sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==",
 			"license": "MIT",
 			"dependencies": {
+				"es-errors": "^1.3.0",
 				"is-core-module": "^2.16.1",
 				"path-parse": "^1.0.7",
 				"supports-preserve-symlinks-flag": "^1.0.0"
@@ -18142,14 +18554,14 @@
 			"license": "MIT"
 		},
 		"node_modules/sass": {
-			"version": "1.97.0",
-			"resolved": "https://registry.npmjs.org/sass/-/sass-1.97.0.tgz",
-			"integrity": "sha512-KR0igP1z4avUJetEuIeOdDlwaUDvkH8wSx7FdSjyYBS3dpyX3TzHfAMO0G1Q4/3cdjcmi3r7idh+KCmKqS+KeQ==",
+			"version": "1.99.0",
+			"resolved": "https://registry.npmjs.org/sass/-/sass-1.99.0.tgz",
+			"integrity": "sha512-kgW13M54DUB7IsIRM5LvJkNlpH+WhMpooUcaWGFARkF1Tc82v9mIWkCbCYf+MBvpIUBSeSOTilpZjEPr2VYE6Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"chokidar": "^4.0.0",
-				"immutable": "^5.0.2",
+				"immutable": "^5.1.5",
 				"source-map-js": ">=0.6.2 <2.0.0"
 			},
 			"bin": {
@@ -18163,9 +18575,9 @@
 			}
 		},
 		"node_modules/sass-loader": {
-			"version": "16.0.6",
-			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.6.tgz",
-			"integrity": "sha512-sglGzId5gmlfxNs4gK2U3h7HlVRfx278YK6Ono5lwzuvi1jxig80YiuHkaDBVsYIKFhx8wN7XSCI0M2IDS/3qA==",
+			"version": "16.0.7",
+			"resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-16.0.7.tgz",
+			"integrity": "sha512-w6q+fRHourZ+e+xA1kcsF27iGM6jdB8teexYCfdUw0sYgcDNeZESnDNT9sUmmPm3ooziwUJXGwZJSTF3kOdBfA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -18179,7 +18591,7 @@
 				"url": "https://opencollective.com/webpack"
 			},
 			"peerDependencies": {
-				"@rspack/core": "0.x || 1.x",
+				"@rspack/core": "0.x || ^1.0.0 || ^2.0.0-0",
 				"node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
 				"sass": "^1.3.0",
 				"sass-embedded": "*",
@@ -18401,22 +18813,26 @@
 			}
 		},
 		"node_modules/serve-index": {
-			"version": "1.9.1",
-			"resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.1.tgz",
-			"integrity": "sha512-pXHfKNP4qujrtteMrSBb0rc8HJ9Ms/GrXwcUtUtD5s4ewDJI8bT3Cz2zTVRMKtri49pLx2e0Ya8ziP5Ya2pZZw==",
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/serve-index/-/serve-index-1.9.2.tgz",
+			"integrity": "sha512-KDj11HScOaLmrPxl70KYNW1PksP4Nb/CLL2yvC+Qd2kHMPEEpfc4Re2e4FOay+bC/+XQl/7zAcWON3JVo5v3KQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"accepts": "~1.3.4",
+				"accepts": "~1.3.8",
 				"batch": "0.6.1",
 				"debug": "2.6.9",
 				"escape-html": "~1.0.3",
-				"http-errors": "~1.6.2",
-				"mime-types": "~2.1.17",
-				"parseurl": "~1.3.2"
+				"http-errors": "~1.8.0",
+				"mime-types": "~2.1.35",
+				"parseurl": "~1.3.3"
 			},
 			"engines": {
 				"node": ">= 0.8.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/express"
 			}
 		},
 		"node_modules/serve-index/node_modules/debug": {
@@ -18440,27 +18856,21 @@
 			}
 		},
 		"node_modules/serve-index/node_modules/http-errors": {
-			"version": "1.6.3",
-			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-			"integrity": "sha512-lks+lVC8dgGyh97jxvxeYTWQFvh4uw4yC12gVl63Cg30sjPX4wuGcdkICVXDAESr6OJGjqGA8Iz5mkeN6zlD7A==",
+			"version": "1.8.1",
+			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+			"integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"depd": "~1.1.2",
-				"inherits": "2.0.3",
-				"setprototypeof": "1.1.0",
-				"statuses": ">= 1.4.0 < 2"
+				"inherits": "2.0.4",
+				"setprototypeof": "1.2.0",
+				"statuses": ">= 1.5.0 < 2",
+				"toidentifier": "1.0.1"
 			},
 			"engines": {
 				"node": ">= 0.6"
 			}
-		},
-		"node_modules/serve-index/node_modules/inherits": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-			"integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw==",
-			"dev": true,
-			"license": "ISC"
 		},
 		"node_modules/serve-index/node_modules/ms": {
 			"version": "2.0.0",
@@ -18468,13 +18878,6 @@
 			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/serve-index/node_modules/setprototypeof": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-			"integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
-			"dev": true,
-			"license": "ISC"
 		},
 		"node_modules/serve-index/node_modules/statuses": {
 			"version": "1.5.0",
@@ -18659,14 +19062,14 @@
 			}
 		},
 		"node_modules/side-channel-list": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-			"integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+			"integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
-				"object-inspect": "^1.13.3"
+				"object-inspect": "^1.13.4"
 			},
 			"engines": {
 				"node": ">= 0.4"
@@ -19088,9 +19491,9 @@
 			}
 		},
 		"node_modules/streamx": {
-			"version": "2.23.0",
-			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.23.0.tgz",
-			"integrity": "sha512-kn+e44esVfn2Fa/O0CPFcex27fjIL6MkVae0Mm6q+E6f0hWv578YCERbv+4m02cjxvDsPKLnmxral/rR6lBMAg==",
+			"version": "2.25.0",
+			"resolved": "https://registry.npmjs.org/streamx/-/streamx-2.25.0.tgz",
+			"integrity": "sha512-0nQuG6jf1w+wddNEEXCF4nTg3LtufWINB5eFEN+5TNZW7KWJp6x87+JFL43vaAUPyCfH1wID+mNVyW6OHtFamg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -19100,21 +19503,14 @@
 			}
 		},
 		"node_modules/string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"safe-buffer": "~5.1.0"
+				"safe-buffer": "~5.2.0"
 			}
-		},
-		"node_modules/string_decoder/node_modules/safe-buffer": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/string-length": {
 			"version": "4.0.2",
@@ -19959,9 +20355,9 @@
 			}
 		},
 		"node_modules/tapable": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.0.tgz",
-			"integrity": "sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==",
+			"version": "2.3.2",
+			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.2.tgz",
+			"integrity": "sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -19973,9 +20369,9 @@
 			}
 		},
 		"node_modules/tar-fs": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.1.tgz",
-			"integrity": "sha512-LZA0oaPOc2fVo82Txf3gw+AkEd38szODlptMYejQUhndHMLQ9M059uXR+AfS7DNo0NpINvSqDsvyaCrBVkptWg==",
+			"version": "3.1.2",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-3.1.2.tgz",
+			"integrity": "sha512-QGxxTxxyleAdyM3kpFs14ymbYmNFrfY+pHj7Z8FgtbZ7w2//VAgLMac7sT6nRpIHjppXO2AwwEOg0bPFVRcmXw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -19988,21 +20384,22 @@
 			}
 		},
 		"node_modules/tar-stream": {
-			"version": "3.1.7",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.7.tgz",
-			"integrity": "sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==",
+			"version": "3.1.8",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.1.8.tgz",
+			"integrity": "sha512-U6QpVRyCGHva435KoNWy9PRoi2IFYCgtEhq9nmrPPpbRacPs9IH4aJ3gbrFC8dPcXvdSZ4XXfXT5Fshbp2MtlQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"b4a": "^1.6.4",
+				"bare-fs": "^4.5.5",
 				"fast-fifo": "^1.2.0",
 				"streamx": "^2.15.0"
 			}
 		},
 		"node_modules/tar-stream/node_modules/b4a": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
-			"integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
+			"integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peerDependencies": {
@@ -20014,10 +20411,20 @@
 				}
 			}
 		},
+		"node_modules/teex": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
+			"integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"streamx": "^2.12.5"
+			}
+		},
 		"node_modules/terser": {
-			"version": "5.44.1",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.44.1.tgz",
-			"integrity": "sha512-t/R3R/n0MSwnnazuPpPNVO60LX0SKL45pyl9YlvxIdkH0Of7D5qM2EVe+yASRIlY5pZ73nclYJfNANGWPwFDZw==",
+			"version": "5.46.1",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.46.1.tgz",
+			"integrity": "sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
@@ -20140,10 +20547,16 @@
 				"node": ">=8"
 			}
 		},
+		"node_modules/test-exclude/node_modules/balanced-match": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+			"license": "MIT"
+		},
 		"node_modules/test-exclude/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+			"version": "1.1.14",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^1.0.0",
@@ -20163,9 +20576,9 @@
 			}
 		},
 		"node_modules/text-decoder": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz",
-			"integrity": "sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==",
+			"version": "1.2.7",
+			"resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
+			"integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -20173,9 +20586,9 @@
 			}
 		},
 		"node_modules/text-decoder/node_modules/b4a": {
-			"version": "1.7.3",
-			"resolved": "https://registry.npmjs.org/b4a/-/b4a-1.7.3.tgz",
-			"integrity": "sha512-5Q2mfq2WfGuFp3uS//0s6baOJLMoVduPYVeNmDYxu5OUA1/cBfvr2RIS7vi62LdNj/urk1hfmj867I3qt6uZ7Q==",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.0.tgz",
+			"integrity": "sha512-qRuSmNSkGQaHwNbM7J78Wwy+ghLEYF1zNrSeMxj4Kgw6y33O3mXcQ6Ie9fRvfU/YnxWkOchPXbaLb73TkIsfdg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peerDependencies": {
@@ -20622,9 +21035,9 @@
 			"license": "MIT"
 		},
 		"node_modules/typescript": {
-			"version": "5.9.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+			"integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"peer": true,
@@ -20998,9 +21411,9 @@
 			}
 		},
 		"node_modules/watchpack": {
-			"version": "2.4.4",
-			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.4.tgz",
-			"integrity": "sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==",
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.5.1.tgz",
+			"integrity": "sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -21046,9 +21459,9 @@
 			}
 		},
 		"node_modules/webpack": {
-			"version": "5.104.1",
-			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.104.1.tgz",
-			"integrity": "sha512-Qphch25abbMNtekmEGJmeRUhLDbe+QfiWTiqpKYkpCOWY64v9eyl+KRRLmqOFA2AvKPpc9DC6+u2n76tQLBoaA==",
+			"version": "5.106.2",
+			"resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.2.tgz",
+			"integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -21058,25 +21471,24 @@
 				"@webassemblyjs/ast": "^1.14.1",
 				"@webassemblyjs/wasm-edit": "^1.14.1",
 				"@webassemblyjs/wasm-parser": "^1.14.1",
-				"acorn": "^8.15.0",
+				"acorn": "^8.16.0",
 				"acorn-import-phases": "^1.0.3",
 				"browserslist": "^4.28.1",
 				"chrome-trace-event": "^1.0.2",
-				"enhanced-resolve": "^5.17.4",
+				"enhanced-resolve": "^5.20.0",
 				"es-module-lexer": "^2.0.0",
 				"eslint-scope": "5.1.1",
 				"events": "^3.2.0",
 				"glob-to-regexp": "^0.4.1",
 				"graceful-fs": "^4.2.11",
-				"json-parse-even-better-errors": "^2.3.1",
 				"loader-runner": "^4.3.1",
-				"mime-types": "^2.1.27",
+				"mime-db": "^1.54.0",
 				"neo-async": "^2.6.2",
 				"schema-utils": "^4.3.3",
 				"tapable": "^2.3.0",
-				"terser-webpack-plugin": "^5.3.16",
-				"watchpack": "^2.4.4",
-				"webpack-sources": "^3.3.3"
+				"terser-webpack-plugin": "^5.3.17",
+				"watchpack": "^2.5.1",
+				"webpack-sources": "^3.3.4"
 			},
 			"bin": {
 				"webpack": "bin/webpack.js"
@@ -21411,13 +21823,23 @@
 			}
 		},
 		"node_modules/webpack-sources": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.3.tgz",
-			"integrity": "sha512-yd1RBzSGanHkitROoPFd6qsrxt+oFhg/129YzheDGqeustzX0vTZJZsSsQjVQC4yzBQ56K55XU8gaNCtIzOnTg==",
+			"version": "3.3.4",
+			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.3.4.tgz",
+			"integrity": "sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/webpack/node_modules/mime-db": {
+			"version": "1.54.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+			"integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
 			}
 		},
 		"node_modules/websocket-driver": {
@@ -21649,9 +22071,9 @@
 			}
 		},
 		"node_modules/ws": {
-			"version": "8.18.3",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-			"integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+			"version": "8.20.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+			"integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -21727,9 +22149,9 @@
 			"license": "ISC"
 		},
 		"node_modules/yaml": {
-			"version": "1.10.2",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
-			"integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+			"version": "1.10.3",
+			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.3.tgz",
+			"integrity": "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA==",
 			"dev": true,
 			"license": "ISC",
 			"engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-loupe",
-	"version": "0.8.4",
+	"version": "0.8.5",
 	"description": "Enhance the search functionality of your WordPress site with WP Loupe.",
 	"main": "index.js",
 	"scripts": {


### PR DESCRIPTION
## Security Dependency Updates

This PR fixes security vulnerabilities detected by Dependabot.

### Changes
- Updated vulnerable dependencies to secure versions
- Applied `npm audit fix`, `pip-audit`, or equivalent for detected ecosystems

### Automated by
[gh-bump](https://github.com/soderlind/gh-bump) - Batch Dependabot fix automation

---


> ⚠️ **Review carefully** before merging. Some updates may introduce breaking changes.