### PR TITLE
Release 0.8.6: rename to Loupe Search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.6] - 2026-07-28
+
+Final release. WP Loupe has been renamed to [Loupe Search](https://github.com/soderlind/loupe-search); all further development continues there.
+
+### Added
+- Dismissible admin notice announcing the rename and linking to the migration guide.
+
+### Deprecated
+- WP Loupe is no longer maintained. Install Loupe Search, deactivate WP Loupe, then activate Loupe Search. Both plugins hook WordPress search and index content, so they must not run at the same time. The existing index at `wp-content/wp-loupe-db` is reused.
+
 ## [0.8.5] - 2026-04-17
 
 ### Security
@@ -507,7 +517,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Code style improvements for better maintainability
 
-[0.8.1]: https://github.com/soderlind/wp-loupe/releases/tag/0.8.1\n[0.8.0]: https://github.com/soderlind/wp-loupe/releases/tag/0.8.0
+[0.8.6]: https://github.com/soderlind/wp-loupe/releases/tag/0.8.6
+[0.8.5]: https://github.com/soderlind/wp-loupe/releases/tag/0.8.5
+[0.8.4]: https://github.com/soderlind/wp-loupe/releases/tag/0.8.4
+[0.8.3]: https://github.com/soderlind/wp-loupe/releases/tag/0.8.3
+[0.8.2]: https://github.com/soderlind/wp-loupe/releases/tag/0.8.2
+[0.8.1]: https://github.com/soderlind/wp-loupe/releases/tag/0.8.1
+[0.8.0]: https://github.com/soderlind/wp-loupe/releases/tag/0.8.0
 [0.7.0]: https://github.com/soderlind/wp-loupe/releases/tag/0.7.0
 [0.6.0]: https://github.com/soderlind/wp-loupe/releases/tag/0.6.0
 [0.5.7]: https://github.com/soderlind/wp-loupe/releases/tag/0.5.7

--- a/includes/class-wp-loupe-deprecation-notice.php
+++ b/includes/class-wp-loupe-deprecation-notice.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Deprecation notice pointing users to Loupe Search.
+ *
+ * @package Soderlind\Plugin\WPLoupe
+ * @since 0.8.6
+ */
+
+declare(strict_types=1);
+namespace Soderlind\Plugin\WPLoupe;
+
+/**
+ * Renders a dismissible admin notice announcing that WP Loupe is superseded by
+ * Loupe Search, and handles persisting the dismissal per user.
+ *
+ * @since 0.8.6
+ */
+class WP_Loupe_Deprecation_Notice {
+
+	/**
+	 * User meta key storing the dismissal flag.
+	 *
+	 * @var string
+	 */
+	private const META_KEY = 'wp_loupe_deprecation_notice_dismissed';
+
+	/**
+	 * Query argument used to trigger a dismissal.
+	 *
+	 * @var string
+	 */
+	private const DISMISS_ARG = 'wp_loupe_dismiss_deprecation';
+
+	/**
+	 * Nonce action for the dismissal link.
+	 *
+	 * @var string
+	 */
+	private const NONCE_ACTION = 'wp_loupe_dismiss_deprecation';
+
+	/**
+	 * Register hooks.
+	 *
+	 * @return void
+	 */
+	public function register(): void {
+		add_action( 'admin_init', [ $this, 'maybe_dismiss' ] );
+		add_action( 'admin_notices', [ $this, 'render' ] );
+	}
+
+	/**
+	 * Handle the dismissal request.
+	 *
+	 * @return void
+	 */
+	public function maybe_dismiss(): void {
+		if ( ! isset( $_GET[ self::DISMISS_ARG ] ) ) {
+			return;
+		}
+
+		if ( ! is_user_logged_in() ) {
+			return;
+		}
+
+		$nonce = isset( $_GET[ '_wpnonce' ] ) ? sanitize_text_field( wp_unslash( $_GET[ '_wpnonce' ] ) ) : '';
+		if ( ! wp_verify_nonce( $nonce, self::NONCE_ACTION ) ) {
+			return;
+		}
+
+		update_user_meta( get_current_user_id(), self::META_KEY, '1' );
+
+		wp_safe_redirect( remove_query_arg( [ self::DISMISS_ARG, '_wpnonce' ] ) );
+		exit;
+	}
+
+	/**
+	 * Output the notice.
+	 *
+	 * @return void
+	 */
+	public function render(): void {
+		if ( ! current_user_can( 'activate_plugins' ) ) {
+			return;
+		}
+
+		if ( get_user_meta( get_current_user_id(), self::META_KEY, true ) ) {
+			return;
+		}
+
+		$dismiss_url = wp_nonce_url(
+			add_query_arg( self::DISMISS_ARG, '1' ),
+			self::NONCE_ACTION
+		);
+
+		printf(
+			'<div class="notice notice-warning"><p><strong>%1$s</strong></p><p>%2$s</p><p>%3$s</p><p><a href="%4$s" class="button button-primary">%5$s</a> <a href="%6$s" class="button">%7$s</a></p></div>',
+			esc_html__( 'WP Loupe is now Loupe Search', 'wp-loupe' ),
+			esc_html__( 'WP Loupe has been renamed to Loupe Search and is no longer maintained under this name. This is the final WP Loupe release; all further development, fixes, and security updates happen in Loupe Search.', 'wp-loupe' ),
+			esc_html__( 'To migrate: install Loupe Search, deactivate WP Loupe, then activate Loupe Search. Both plugins hook WordPress search and index content, so running them at the same time will cause conflicts. Your existing index is reused, so no reindexing is required.', 'wp-loupe' ),
+			esc_url( 'https://wordpress.org/plugins/loupe-search/' ),
+			esc_html__( 'Get Loupe Search', 'wp-loupe' ),
+			esc_url( 'https://github.com/soderlind/loupe-search/blob/main/docs/renamed-from-wp-loupe.md' ),
+			esc_html__( 'Migration guide', 'wp-loupe' )
+		);
+	}
+}

--- a/includes/class-wp-loupe-loader.php
+++ b/includes/class-wp-loupe-loader.php
@@ -49,6 +49,7 @@ class WP_Loupe_Loader {
 		require_once WP_LOUPE_PATH . 'includes/class-wp-loupe-utils.php';
 		require_once WP_LOUPE_PATH . 'includes/class-wp-loupe-settings.php';
 		require_once WP_LOUPE_PATH . 'includes/class-wp-loupe-rest.php';
+		require_once WP_LOUPE_PATH . 'includes/class-wp-loupe-deprecation-notice.php';
 		// MCP server class
 		require_once WP_LOUPE_PATH . 'includes/class-wp-loupe-mcp-server.php';
 	}
@@ -96,6 +97,11 @@ class WP_Loupe_Loader {
 
 		// Initialize REST API handler
 		new WP_Loupe_REST();
+
+		// Announce the rename to Loupe Search.
+		if ( is_admin() ) {
+			( new WP_Loupe_Deprecation_Notice() )->register();
+		}
 
 		// Initialize MCP Server (lazy hooks)
 		WP_Loupe_MCP_Server::get_instance();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "wp-loupe",
-	"version": "0.8.5",
+	"version": "0.8.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "wp-loupe",
-			"version": "0.8.5",
+			"version": "0.8.6",
 			"license": "GPLv2",
 			"dependencies": {
 				"@soderlind/wp-project-version-sync": "^2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "wp-loupe",
-	"version": "0.8.5",
+	"version": "0.8.6",
 	"description": "Enhance the search functionality of your WordPress site with WP Loupe.",
 	"main": "index.js",
 	"scripts": {

--- a/readme.txt
+++ b/readme.txt
@@ -4,14 +4,24 @@ Tags: search, full-text search, relevance, typo-tolerant, fast search, search en
 Requires at least: 6.7
 Tested up to: 7.0
 Requires PHP: 8.3
-Stable tag: 0.8.5
+Stable tag: 0.8.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Donate link: https://paypal.me/PerSoderlind
 
-A search enhancement plugin for WordPress that delivers fast, accurate, and typo-tolerant results.
+A search enhancement plugin for WordPress that delivers fast, accurate, and typo-tolerant results. Renamed to Loupe Search.
 
 == Description ==
+
+**WP Loupe is now Loupe Search.** This is the final WP Loupe release. Development continues as [Loupe Search](https://wordpress.org/plugins/loupe-search/), which is where all future features, fixes, and security updates land.
+
+To migrate:
+
+1. Install Loupe Search.
+2. Deactivate WP Loupe.
+3. Activate Loupe Search.
+
+Deactivate WP Loupe *before* activating Loupe Search — both plugins hook WordPress search and index content, so running them together causes conflicts. Your existing index at `wp-content/wp-loupe-db` is reused, so no reindexing is needed. See the [migration guide](https://github.com/soderlind/loupe-search/blob/main/docs/renamed-from-wp-loupe.md).
 
 WP Loupe improves WordPress core search by maintaining its own index for fast lookups, supporting typo tolerance, phrase matching, basic exclusion operators, and per–post-type customization.
 
@@ -152,6 +162,11 @@ Use Settings > WP Loupe > Reindex (batched), or run via WP-CLI:
 
 
 == Changelog ==
+
+= 0.8.6 =
+* Final release. WP Loupe has been renamed to Loupe Search; all further development continues there.
+* Added: Dismissible admin notice announcing the rename and linking to the migration guide.
+* Deprecated: WP Loupe is no longer maintained. Install Loupe Search, deactivate WP Loupe, then activate Loupe Search. The existing index is reused.
 
 = 0.8.5 =
 * Security: Updated PHP and JavaScript dependencies to resolve reported security advisories.

--- a/wp-loupe.php
+++ b/wp-loupe.php
@@ -8,9 +8,9 @@
  *
  * @wordpress-plugin
  * Plugin Name:       WP Loupe
- * Plugin URI:        https://github.com/soderlind/wp-loupe
- * Description:       Enhance the search functionality of your WordPress site with WP Loupe.
- * Version:           0.8.5
+ * Plugin URI:        https://github.com/soderlind/loupe-search
+ * Description:       Enhance the search functionality of your WordPress site with WP Loupe. This plugin has been renamed and is continued as Loupe Search.
+ * Version:           0.8.6
  * Author:            Per Soderlind
  * Author URI:        https://soderlind.no
  * License:           GPL-2.0+
@@ -35,7 +35,7 @@ define( 'WP_LOUPE_PATH', plugin_dir_path( WP_LOUPE_FILE ) );
 define( 'WP_LOUPE_URL', plugin_dir_url( WP_LOUPE_FILE ) );
 // MCP related constants (development token & version marker)
 if ( ! defined( 'WP_LOUPE_MCP_VERSION' ) ) {
-	define( 'WP_LOUPE_MCP_VERSION', '0.8.5' );
+	define( 'WP_LOUPE_MCP_VERSION', '0.8.6' );
 }
 // Optional development bearer token for initial implementation (SHOULD be disabled in production)
 if ( ! defined( 'WP_LOUPE_MCP_DEV_TOKEN' ) ) {


### PR DESCRIPTION
WP Loupe is superseded by soderlind/loupe-search. This final release bumps the version so existing installs are offered the update, and surfaces a dismissible admin notice pointing at Loupe Search and the migration guide.

- Bump version to 0.8.6 across plugin header, readme.txt and npm manifests
- Add WP_Loupe_Deprecation_Notice, registered from the loader in admin only
- Document the rename in CHANGELOG.md and readme.txt
- Repair a literal \n that merged the 0.8.1/0.8.0 changelog link definitions and add the missing 0.8.2-0.8.6 definitions